### PR TITLE
Misc Fixes

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -7,8 +7,8 @@ cephx_require_signatures: false # Kernel RBD does NOT support signatures!
 cephx_cluster_require_signatures: true
 cephx_service_require_signatures: false
 
-node_name: "{{ ansible_hostname }}"
-node_addr: "{{ hostvars[ansible_hostname]['ansible_' + monitor_interface]['ipv4']['address'] }}"
+node_name: "{{ inventory_hostname }}"
+node_addr: "{{ hostvars[inventory_hostname]['ansible_' + monitor_interface]['ipv4']['address'] }}"
 
 crush_location: false
 osd_crush_location: "'root={{ ceph_crush_root }} rack={{ ceph_crush_rack }} host={{ ansible_hostname }}'"

--- a/roles/etcd/templates/etcd.j2
+++ b/roles/etcd/templates/etcd.j2
@@ -41,9 +41,9 @@ start)
         export ETCD_INITIAL_CLUSTER="
         {%- for host in groups[etcd_peers_group] -%}
         {%- if loop.last -%}
-        {{ hostvars[host]['ansible_hostname'] }}=http://{{ hostvars[host]['ansible_' + etcd_peer_interface]['ipv4']['address'] }}:{{ etcd_peer_port1 }},{{ hostvars[host]['ansible_hostname'] }}=http://{{ hostvars[host]['ansible_' + etcd_peer_interface]['ipv4']['address'] }}:{{ etcd_peer_port2 }}
+        {{ hostvars[host]['inventory_hostname'] }}=http://{{ hostvars[host]['ansible_' + etcd_peer_interface]['ipv4']['address'] }}:{{ etcd_peer_port1 }},{{ hostvars[host]['inventory_hostname'] }}=http://{{ hostvars[host]['ansible_' + etcd_peer_interface]['ipv4']['address'] }}:{{ etcd_peer_port2 }}
         {%- else -%}
-        {{ hostvars[host]['ansible_hostname'] }}=http://{{ hostvars[host]['ansible_' + etcd_peer_interface]['ipv4']['address'] }}:{{ etcd_peer_port1 }},{{ hostvars[host]['ansible_hostname'] }}=http://{{ hostvars[host]['ansible_' + etcd_peer_interface]['ipv4']['address'] }}:{{ etcd_peer_port2 }},
+        {{ hostvars[host]['inventory_hostname'] }}=http://{{ hostvars[host]['ansible_' + etcd_peer_interface]['ipv4']['address'] }}:{{ etcd_peer_port1 }},{{ hostvars[host]['inventory_hostname'] }}=http://{{ hostvars[host]['ansible_' + etcd_peer_interface]['ipv4']['address'] }}:{{ etcd_peer_port2 }},
         {%- endif -%}
         {% endfor -%}
         "

--- a/roles/etcd/vars/main.yml
+++ b/roles/etcd/vars/main.yml
@@ -5,8 +5,13 @@ etcd_client_port1: 2379
 etcd_client_port2: 4001
 etcd_peer_port1: 2380
 etcd_peer_port2: 7001
-etcd_master_addr: "{{ node_addr }}"
-etcd_master_name: "{{ node_name }}"
 etcd_peers_group: "service-master"
 etcd_peer_interface: "{{ monitor_interface }}"
 etcd_init_cluster: true
+
+
+# following variables are used in one or more roles, but have no good default value to pick from.
+# Leaving them as commented so that playbooks can fail early due to variable not defined error.
+
+#etcd_master_addr:
+#etcd_master_name:

--- a/roles/etcd/vars/main.yml
+++ b/roles/etcd/vars/main.yml
@@ -11,7 +11,7 @@ etcd_init_cluster: true
 
 
 # following variables are used in one or more roles, but have no good default value to pick from.
-# Leaving them as commented so that playbooks can fail early due to variable not defined error.
+# Leaving them as commented so that playbooks can fail early with variable not defined error.
 
 #etcd_master_addr:
 #etcd_master_name:

--- a/roles/ucarp/templates/ucarp.sh.j2
+++ b/roles/ucarp/templates/ucarp.sh.j2
@@ -11,7 +11,7 @@ set -x -e
 case $1 in
 start)
     /sbin/ucarp --shutdown --interface={{ monitor_interface }} \
-        --srcip={{ hostvars[ansible_hostname]['ansible_' + monitor_interface]['ipv4']['address'] }} \
+        --srcip={{ hostvars[inventory_hostname]['ansible_' + monitor_interface]['ipv4']['address'] }} \
         --vhid=1 --pass=cluster_secret --addr={{ service_vip }} \
         --upscript="/usr/bin/ucarp/vip_up.sh" --downscript="/usr/bin/ucarp/vip_down.sh"
     ;;


### PR DESCRIPTION
- replaced ansible_hostname with inventory_hostname to allow running palybooks in environments where the hostname doesn't necessarily match the inventory name.
- made etcd master addr and name variables undefined to fail early than resulting in a mis-configured cluster.

@erikh PTAL. I think we have discussed about `inventory_hostname` name issue in past but wasn't sure if you already had something like this in works.
