### PR TITLE
add stop script for collins service

### DIFF
--- a/roles/contiv_cluster/files/collins.service
+++ b/roles/contiv_cluster/files/collins.service
@@ -4,4 +4,5 @@ After=auditd.service systemd-user-sessions.service time-sync.target docker.servi
 
 [Service]
 ExecStart=/usr/bin/collins.sh start
+ExecStop=/usr/bin/collins.sh stop
 KillMode=control-group

--- a/roles/contiv_cluster/templates/collins.j2
+++ b/roles/contiv_cluster/templates/collins.j2
@@ -13,6 +13,12 @@ start)
     /usr/bin/docker run -t -p {{ collins_host_port }}:{{ collins_guest_port }} --name collins tumblr/collins
     ;;
 
+stop)
+    # don't stop on error
+    /usr/bin/docker stop collins
+    /usr/bin/docker rm collins
+    ;;
+
 *)
     echo USAGE: $usage
     exit 1


### PR DESCRIPTION
@erikh PTAL when you get a chance. This is needed to be able to restart collins as part of cluster manager systemtests but might be helpful otherwise as well.
