### PR TITLE
reorganize the base role

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+#ide files
+*.swp
+
+# ansible fetch dir
+fetch/*

--- a/roles/base/tasks/main.yml
+++ b/roles/base/tasks/main.yml
@@ -13,9 +13,6 @@
     name: '*'
     state: latest
   when: ansible_os_family == "RedHat"
-- name: install openstack kilo repo
-  yum: "name=https://repos.fedorapeople.org/repos/openstack/openstack-kilo/rdo-release-kilo-1.noarch.rpm"
-  when: ansible_os_family == "RedHat"
 - name: install base packages (debian)
   apt:
     name: "{{ item }}"
@@ -54,68 +51,6 @@
 - name: install and start ntp
   shell: systemctl enable ntpd
   when: ansible_os_family == "RedHat"
-- name: check if golang is installed
-  stat: path=/usr/local/go/bin/go
-  register: golang_bin
-- name: download Golang v1.5.2
-  get_url:
-    validate_certs: no
-    url: https://storage.googleapis.com/golang/go1.5.2.linux-amd64.tar.gz
-    dest: /tmp/golang.tar.gz
-  when: golang_bin.stat.exists == false
-- name: install Golang v1.5.2
-  shell: chdir=/usr/local/ tar xfvz /tmp/golang.tar.gz
-  when: golang_bin.stat.exists == false
-- name: download etcd v2.1.1
-  get_url: 
-    validate_certs: no
-    url: https://github.com/coreos/etcd/releases/download/v2.1.1/etcd-v2.1.1-linux-amd64.tar.gz
-    dest: /tmp/etcd.tar.gz
-- name: install etcd
-  shell: creates=/usr/bin/etcd tar vxzf /tmp/etcd.tar.gz && mv etcd-v2.1.1-linux-amd64/etcd* /usr/bin
-- name: setup golang environment 
-  copy:
-    dest: /etc/profile.d/00golang.sh
-    content: "export PATH=/opt/golang/bin:/usr/local/go/bin:$PATH\nexport GOPATH=/opt/golang"
-- name: install docker
-  shell: creates=/usr/bin/docker curl https://get.docker.com | bash
-- name: add vagrant user to docker group
-  user: name=vagrant groups=docker append=yes
-- name: download and install swarm
-  get_url:
-    validate_certs: no
-    url: https://cisco.box.com/shared/static/0txiq5h7282hraujk09eleoevptd5jpl
-    dest: /usr/bin/swarm
-    mode: u=rwx,g=rx,o=rx
-- name: download ovs binaries (debian)
-  get_url:
-    validate_certs: no
-    dest: "{{ item.dest }}"
-    url: "{{ item.url }}"
-  with_items:
-    - { 
-        url: "https://cisco.box.com/shared/static/v1dvgoboo5zgqrtn6tu27vxeqtdo2bdl.deb",
-        dest: /tmp/ovs-common.deb
-      }
-    - { 
-        url: "https://cisco.box.com/shared/static/ymbuwvt2qprs4tquextw75b82hyaxwon.deb",
-        dest: /tmp/ovs-switch.deb
-      }
-  when: ansible_os_family == "Debian"
-- name: install ovs-common (debian)
-  apt: "deb=/tmp/ovs-common.deb"
-  when: ansible_os_family == "Debian"
-- name: install ovs (debian)
-  apt: "deb=/tmp/ovs-switch.deb"
-  when: ansible_os_family == "Debian"
-- name: start ovs service
-  service: "name=openvswitch enabled=yes state=started"
-  when: ansible_os_family == "RedHat"
-- name: setup ovs
-  shell: "ovs-vsctl set-manager {{ item }}"
-  with_items:
-    - "tcp:127.0.0.1:6640"
-    - "ptcp:6640"
 - name: download consul binary 
   get_url: 
     validate_certs: no

--- a/roles/contiv_network/tasks/main.yml
+++ b/roles/contiv_network/tasks/main.yml
@@ -1,6 +1,10 @@
 ---
 # This role contains tasks for configuring and starting netmaster and netplugin service
 
+# install ovs, needed for our netplugin deployments. In future, if needed, this
+# install can be conditional based on deployment environment.
+- include: ovs.yml
+
 - name: download netmaster and netplugin
   get_url:
     validate_certs: no

--- a/roles/contiv_network/tasks/ovs.yml
+++ b/roles/contiv_network/tasks/ovs.yml
@@ -1,0 +1,40 @@
+---
+# This role contains tasks for installing ovs
+
+- name: install openstack kilo repo
+  yum: "name=https://repos.fedorapeople.org/repos/openstack/openstack-kilo/rdo-release-kilo-1.noarch.rpm"
+  when: ansible_os_family == "RedHat"
+
+- name: download ovs binaries (debian)
+  get_url:
+    validate_certs: no
+    dest: "{{ item.dest }}"
+    url: "{{ item.url }}"
+  with_items:
+    - {
+        url: "https://cisco.box.com/shared/static/v1dvgoboo5zgqrtn6tu27vxeqtdo2bdl.deb",
+        dest: /tmp/ovs-common.deb
+      }
+    - {
+        url: "https://cisco.box.com/shared/static/ymbuwvt2qprs4tquextw75b82hyaxwon.deb",
+        dest: /tmp/ovs-switch.deb
+      }
+  when: ansible_os_family == "Debian"
+
+- name: install ovs-common (debian)
+  apt: "deb=/tmp/ovs-common.deb"
+  when: ansible_os_family == "Debian"
+
+- name: install ovs (debian)
+  apt: "deb=/tmp/ovs-switch.deb"
+  when: ansible_os_family == "Debian"
+
+- name: start ovs service
+  service: "name=openvswitch enabled=yes state=started"
+  when: ansible_os_family == "RedHat"
+
+- name: setup ovs
+  shell: "ovs-vsctl set-manager {{ item }}"
+  with_items:
+    - "tcp:127.0.0.1:6640"
+    - "ptcp:6640"

--- a/roles/dev/meta/main.yml
+++ b/roles/dev/meta/main.yml
@@ -1,0 +1,9 @@
+---
+# The dependecies contains tasks for installing development packages
+# We also use this role to pre-bake packages in the OS image for our development
+# environment.
+# XXX: need to figure a way to download and prebake more binaries like
+# docker, etcd, swarm etc
+
+dependencies:
+- { role: ceph-install }

--- a/roles/dev/tasks/main.yml
+++ b/roles/dev/tasks/main.yml
@@ -1,0 +1,22 @@
+---
+# This role contains tasks for installing development packages
+# We also use this role to pre-bake packages in the OS image for our development
+# environment.
+
+- name: download Golang v1.5.2
+  get_url:
+    validate_certs: no
+    url: https://storage.googleapis.com/golang/go1.5.2.linux-amd64.tar.gz
+    dest: /tmp/go1.5.2.linux-amd64.tar.gz
+    force: no
+
+- name: install Golang
+  shell: chdir=/usr/local/ creates=/usr/local/go/bin/go tar xfvz /tmp/go1.5.2.linux-amd64.tar.gz
+
+- name: setup golang environment
+  copy:
+    dest: /etc/profile.d/00golang.sh
+    content: "export PATH=/opt/golang/bin:/usr/local/go/bin:$PATH; export GOPATH=/opt/golang"
+
+# pre-install ovs
+- include: ../../contiv_network/tasks/ovs.yml

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -1,6 +1,10 @@
 ---
 # This role contains tasks for configuring and starting docker service
 
+# XXX: figure a way to download a specific docker version
+- name: install docker
+  shell: creates=/usr/bin/docker curl https://get.docker.com | bash
+
 - name: create docker daemon's config directory
   file: path=/etc/systemd/system/docker.service.d state=directory
 

--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -1,6 +1,16 @@
 ---
 # This role contains tasks for configuring and starting etcd service
 
+- name: download etcd v2.1.1
+  get_url:
+    validate_certs: no
+    url: https://github.com/coreos/etcd/releases/download/v2.1.1/etcd-v2.1.1-linux-amd64.tar.gz
+    dest: /tmp/etcd-v2.1.1-linux-amd64.tar.gz
+    force: no
+
+- name: install etcd
+  shell: creates=/usr/bin/etcd tar vxzf /tmp/etcd-v2.1.1-linux-amd64.tar.gz && mv etcd-v2.1.1-linux-amd64/etcd* /usr/bin
+
 - name: copy the etcd start/stop script
   template: src=etcd.j2 dest=/usr/bin/etcd.sh mode=u=rwx,g=rx,o=rx
 

--- a/roles/swarm/tasks/main.yml
+++ b/roles/swarm/tasks/main.yml
@@ -1,6 +1,14 @@
 ---
 # This role contains tasks for configuring and starting swarm service
 
+- name: download and install swarm
+  get_url:
+    validate_certs: no
+    url: https://cisco.box.com/shared/static/0txiq5h7282hraujk09eleoevptd5jpl
+    dest: /usr/bin/swarm
+    mode: u=rwx,g=rx,o=rx
+    force: no
+
 - name: copy the swarm start/stop script
   template: src=swarm.j2 dest=/usr/bin/swarm.sh mode=u=rwx,g=rx,o=rx
 

--- a/site.yml
+++ b/site.yml
@@ -3,15 +3,13 @@
 
 # devtest hosts correspond to the dev, lab and vagrant based machines for contiv projects.
 # Here we will install the base packages needed for those environments.
-# XXX: this is used by the 'contiv/build' project right now. But hopefully soon
-# we can use it as replacement for 'contiv/lab' with some more refinements.
 - hosts: devtest
   sudo: true
   environment: env
   roles:
   - { role: base }
+  - { role: dev }
   - { role: serf }
-  - { role: ceph-install }
 
 - hosts: volplugin-test
   sudo: true


### PR DESCRIPTION
- move package installations close to respective roles
- add dev role to make the development environment related pre-packaging more explicit. 'dev' role shall be used for putting in dev environment related dependencies like build tools or pre-packaging large binaries to save download times.

This addresses #11. This is more of organizational change, so I tried to minimize any major logic changes/fixes. I tried this out in cluster repo and looks fine.

cc/ @erikh @jainvipin 

Next step, we can continue to identify more tasks/roles to be includes as dependecies for `dev` in order to pre-package more things (like container images used by our projects etc) which will hopefully expedite bringing up our dev-test environments, while keeping our ansible roles production ready.
