### PR TITLE
deploy released version of clusterm in contiv_cluster

### DIFF
--- a/roles/contiv_cluster/tasks/main.yml
+++ b/roles/contiv_cluster/tasks/main.yml
@@ -8,20 +8,20 @@
   copy: src=collins.service dest=/etc/systemd/system/collins.service
 
 - name: start collins
-  shell: systemctl daemon-reload && systemctl start collins
+  service: name=collins state=started
 
-# XXX: revisit once we have cluster-manager releases available
 - name: download clusterm
-  shell: /bin/true
-  ignore_errors: yes
+  get_url:
+    validate_certs: no
+    url: https://github.com/contiv/cluster/releases/download/v0.0.0-01-05-2016.22-21-32.UTC/cluster-v0.0.0-01-05-2016.22-21-32.UTC.tar.bz2
+    dest: /tmp/cluster-v0.0.0-01-05-2016.22-21-32.UTC.tar.bz2
+    force: no
 
-# XXX: revisit once we have cluster-manager releases available
 - name: install clusterm
-  file: src=/opt/gopath/bin/{{ item.name }} dest=/usr/bin/{{ item.name }} state=link
-  with_items:
-    - { name: clusterm }
-    - { name: clusterctl }
-  ignore_errors: yes
+  shell: tar vxjf /tmp/cluster-v0.0.0-01-05-2016.22-21-32.UTC.tar.bz2
+  args:
+    chdir: /usr/bin/
+    creates: clusterm
 
 - name: copy environment file for clusterm
   copy: src=clusterm dest=/etc/default/clusterm
@@ -30,4 +30,4 @@
   copy: src=clusterm.service dest=/etc/systemd/system/clusterm.service
 
 - name: start clusterm
-  shell: systemctl daemon-reload && systemctl start clusterm
+  service: name=clusterm state=started

--- a/site.yml
+++ b/site.yml
@@ -31,6 +31,7 @@
   sudo: true
   environment: env
   roles:
+  - { role: base }
   - { role: docker, etcd_client_port1: 2379 }
   - { role: contiv_cluster }
 
@@ -40,6 +41,7 @@
   sudo: true
   environment: env
   roles:
+  - { role: base }
   - { role: ucarp }
   - { role: docker }
   - { role: etcd, run_as: master }
@@ -55,6 +57,7 @@
   sudo: true
   environment: env
   roles:
+  - { role: base }
   - { role: docker }
   - { role: etcd, run_as: worker }
   - { role: ceph-osd, mon_group_name: service-master, osd_group_name: service-worker }


### PR DESCRIPTION
This one shall not need a special review as it just brings in deploying cluster-manager's released images like other services. I will merge this after verifying it in the cluster repo. 
