### PR TITLE
Misc fixes and enhancements

### DIFF
--- a/roles/base/tasks/main.yml
+++ b/roles/base/tasks/main.yml
@@ -48,7 +48,6 @@
     - curl
     - git
     - mercurial
-    - openvswitch
     - gcc
     - perl
     - librbd1-devel

--- a/roles/base/tasks/main.yml
+++ b/roles/base/tasks/main.yml
@@ -4,7 +4,6 @@
 - name: upgrade system (debian)
   apt:
     update_cache: true
-    name: '*'
     state: latest
   when: ansible_os_family == "Debian"
 

--- a/roles/base/tasks/main.yml
+++ b/roles/base/tasks/main.yml
@@ -19,6 +19,7 @@
     name: "{{ item }}"
   with_items:
     - unzip
+    - bzip2
     - vim-nox
     - curl
     - python-software-properties
@@ -43,6 +44,7 @@
   with_items:
     - ntp
     - unzip
+    - bzip2
     - vim
     - curl
     - git

--- a/roles/base/tasks/main.yml
+++ b/roles/base/tasks/main.yml
@@ -7,12 +7,14 @@
     name: '*'
     state: latest
   when: ansible_os_family == "Debian"
+
 - name: upgrade system (redhat)
   yum:
     update_cache: true
     name: '*'
     state: latest
   when: ansible_os_family == "RedHat"
+
 - name: install base packages (debian)
   apt:
     name: "{{ item }}"
@@ -29,11 +31,17 @@
     - lshw
     - python-pip
   when: ansible_os_family == "Debian"
+
+# install epel-release first to ensure the extra packages can be installed later
+- name: install epel release package (redhat)
+  yum:
+    name: epel-release
+  when: ansible_os_family == "RedHat"
+
 - name: install base packages (redhat)
   yum:
     name: "{{ item }}"
   with_items:
-    - epel-release
     - ntp
     - unzip
     - vim
@@ -48,18 +56,35 @@
     - python-pip
     - python-requests # XXX required by ceph repo, but it has a bad package on it
   when: ansible_os_family == "RedHat"
+
 - name: install and start ntp
   shell: systemctl enable ntpd
   when: ansible_os_family == "RedHat"
+
 - name: download consul binary 
   get_url: 
     validate_certs: no
     url: https://dl.bintray.com/mitchellh/consul/0.5.2_linux_amd64.zip
     dest: /tmp/consul.zip
+
 - name: install consul
   shell: "chdir=/tmp creates=/usr/bin/consul unzip /tmp/consul.zip && mv /tmp/consul /usr/bin"
 
-#NOTE: Upgrade pip to latest which is useful for installation of packages like docker-compose
+- name: install ansible (redhat)
+  yum: name=ansible state=present
+  when: ansible_os_family == "RedHat"
+
+- name: add ansible apt repository (debian)
+  apt_repository: repo=ppa:ansible/ansible state=present
+  when: ansible_os_family == "Debian"
+
+- name: install ansible (debian)
+  apt: name=ansible state=present
+  when: ansible_os_family == "Debian"
+
+#NOTE: Upgrade pip to latest which is needed for correct installation of docker-compose
+#XXX: This messes with the python packages already installed causing any yum/apt
+#re-run to fail subsequently. We need a different way to update pip.
 - name: upgrade pip
   pip:
     name: pip

--- a/roles/contiv_network/tasks/ovs.yml
+++ b/roles/contiv_network/tasks/ovs.yml
@@ -1,8 +1,12 @@
 ---
 # This role contains tasks for installing ovs
 
-- name: install openstack kilo repo
+- name: install openstack kilo repo (redhat)
   yum: "name=https://repos.fedorapeople.org/repos/openstack/openstack-kilo/rdo-release-kilo-1.noarch.rpm"
+  when: ansible_os_family == "RedHat"
+
+- name: install ovs (redhat)
+  yum: name=openvswitch state=present
   when: ansible_os_family == "RedHat"
 
 - name: download ovs binaries (debian)

--- a/roles/dev/tasks/main.yml
+++ b/roles/dev/tasks/main.yml
@@ -11,12 +11,90 @@
     force: no
 
 - name: install Golang
-  shell: chdir=/usr/local/ creates=/usr/local/go/bin/go tar xfvz /tmp/go1.5.2.linux-amd64.tar.gz
+  shell: tar xfvz /tmp/go1.5.2.linux-amd64.tar.gz
+  args:
+    chdir: /usr/local/
+    creates: /usr/local/go/bin/go
 
 - name: setup golang environment
   copy:
     dest: /etc/profile.d/00golang.sh
     content: "export PATH=/opt/golang/bin:/usr/local/go/bin:$PATH; export GOPATH=/opt/golang"
+
+- name: check packer's version
+  shell: packer --version
+  register: packer_version
+  ignore_errors: yes
+
+- name: download packer
+  get_url:
+    validate_certs: no
+    url: https://releases.hashicorp.com/packer/0.8.6/packer_0.8.6_linux_amd64.zip
+    dest: /tmp/packer_0.8.6_linux_amd64.zip
+    force: no
+  when: packer_version.stdout != "0.8.6"
+
+- name: install packer
+  shell: rm -f packer* && unzip /tmp/packer_0.8.6_linux_amd64.zip
+  args:
+    chdir: /usr/local/bin
+  when: packer_version.stdout != "0.8.6"
+
+- name: download VBox (debian)
+  get_url:
+    validate_certs: no
+    url: http://download.virtualbox.org/virtualbox/5.0.12/virtualbox-5.0_5.0.12-104815~Ubuntu~trusty_amd64.deb
+    dest: /tmp/virtualbox-5.0_5.0.12-104815~Ubuntu~trusty_amd64.deb
+    force: no
+  when: ansible_os_family == "Debian"
+
+- name: install VBox (debian)
+  apt: deb=/tmp/virtualbox-5.0_5.0.12-104815~Ubuntu~trusty_amd64.deb state=present
+  when: ansible_os_family == "Debian"
+
+- name: install VBox dkms (debian)
+  apt: name=dkms state=present
+  when: ansible_os_family == "Debian"
+
+- name: download VBox (redhat)
+  get_url:
+    validate_certs: no
+    url: http://download.virtualbox.org/virtualbox/5.0.12/VirtualBox-5.0-5.0.12_104815_el7-1.x86_64.rpm
+    dest: /tmp/VirtualBox-5.0-5.0.12_104815_el7-1.x86_64.rpm
+    force: no
+  when: ansible_os_family == "RedHat"
+
+- name: install VBox (redhat)
+  yum: name=/tmp/VirtualBox-5.0-5.0.12_104815_el7-1.x86_64.rpm state=present
+  when: ansible_os_family == "RedHat"
+
+- name: install VBox dkms (redhat)
+  yum: name=dkms state=present
+  when: ansible_os_family == "RedHat"
+
+- name: download vagrant (debian)
+  get_url:
+    validate_certs: no
+    url: https://releases.hashicorp.com/vagrant/1.8.1/vagrant_1.8.1_x86_64.deb
+    dest: /tmp/vagrant_1.8.1_x86_64.deb
+    force: no
+  when: ansible_os_family == "Debian"
+
+- name: install vagrant (debian)
+  apt: deb=/tmp/vagrant_1.8.1_x86_64.deb state=present
+  when: ansible_os_family == "Debian"
+
+- name: download vagrant (redhat)
+  get_url:
+    validate_certs: no
+    url: https://releases.hashicorp.com/vagrant/1.8.1/vagrant_1.8.1_x86_64.rpm
+    dest: /tmp/vagrant_1.8.1_x86_64.rpm
+    force: no
+  when: ansible_os_family == "RedHat"
+
+- name: install vagrant (redhat)
+  yum: name=/tmp/vagrant_1.8.1_x86_64.rpm state=present
+  when: ansible_os_family == "RedHat"
 
 # pre-install ovs
 - include: ../../contiv_network/tasks/ovs.yml


### PR DESCRIPTION
- install ansible, packer, vagrant and virtualbox in respective roles
  - ansible is a base package as it will be used for cluster provisioning
  - packer, vagrant and virtualbox are dev environment related tools and will enable us to setup or baremetal host environments.
- fixed openvswitch installation for redhat
  - a task got leftover in `base` role as part of `dev` role change, which causes base role to fail.
- fixed yum package installation by separating out epel-release into it's own task
  - otherwise the packages that depend on it fail
- fixed apt package update task to just update the list and no try to update all installed packages
  - otherwise the task fails with conflicts
- install bzip2 in base packages (fixes #22)

/cc @erikh 
