### PR TITLE
Misc fixes

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,6 +21,7 @@ ansible_groups = { }
 ansible_playbook = "./site.yml"
 ansible_extra_vars = {
     "env" => host_env,
+    "validate_certs" => "no",
 }
 
 puts "Host environment: #{host_env}"

--- a/group_vars/all
+++ b/group_vars/all
@@ -13,6 +13,8 @@ node_addr: "{{ hostvars[inventory_hostname]['ansible_' + monitor_interface]['ipv
 crush_location: false
 osd_crush_location: "'root={{ ceph_crush_root }} rack={{ ceph_crush_rack }} host={{ ansible_hostname }}'"
 
+validate_certs: "yes"
+
 # following variables are used in one or more roles, but have no good default value to pick from.
 # Leaving them as commented so that playbooks can fail early due to variable not defined error.
 

--- a/roles/base/tasks/os_agnostic_tasks.yml
+++ b/roles/base/tasks/os_agnostic_tasks.yml
@@ -1,6 +1,6 @@
 - name: download consul binary
   get_url:
-    validate_certs: no
+    validate_certs: "{{ validate_certs }}"
     url: https://dl.bintray.com/mitchellh/consul/0.5.2_linux_amd64.zip
     dest: /tmp/consul.zip
 

--- a/roles/base/tasks/redhat_tasks.yml
+++ b/roles/base/tasks/redhat_tasks.yml
@@ -30,5 +30,14 @@
 - name: install and start ntp
   shell: systemctl enable ntpd
 
+- name: install python-crypto
+  yum: name=python-crypto state=present
+  register: python_crypto_result
+  ignore_errors: yes
+
+- name: remove python crypt egg file to work-around https://bugs.centos.org/view.php?id=9896&nbn=2
+  shell: rm -rf /usr/lib64/python2.7/site-packages/pycrypto-2.6.1-py2.7.egg-info
+  when: python_crypto_result.msg == "Error unpacking rpm package python-crypto-2.6.1-1.el7.centos.x86_64\n"
+
 - name: install ansible (redhat)
   yum: name=ansible state=present

--- a/roles/base/tasks/ubuntu_tasks.yml
+++ b/roles/base/tasks/ubuntu_tasks.yml
@@ -21,7 +21,7 @@
     - python-pip
 
 - name: add ansible apt repository (debian)
-  apt_repository: repo=ppa:ansible/ansible state=present
+  apt_repository: repo=ppa:ansible/ansible state=present validate_certs=no
 
 - name: install ansible (debian)
   apt: name=ansible state=present

--- a/roles/base/tasks/ubuntu_tasks.yml
+++ b/roles/base/tasks/ubuntu_tasks.yml
@@ -21,7 +21,10 @@
     - python-pip
 
 - name: add ansible apt repository (debian)
-  apt_repository: repo=ppa:ansible/ansible state=present validate_certs=no
+  apt_repository:
+    repo: ppa:ansible/ansible
+    state: present
+    validate_certs: "{{ validate_certs }}"
 
 - name: install ansible (debian)
   apt: name=ansible state=present

--- a/roles/ceph-common/tasks/installs/install_rgw_on_redhat.yml
+++ b/roles/ceph-common/tasks/installs/install_rgw_on_redhat.yml
@@ -9,6 +9,7 @@
 - name: add special fastcgi repository key
   rpm_key:
     key: http://dag.wieers.com/rpm/packages/RPM-GPG-KEY.dag.txt
+    validate_certs: no
 
 - name: add special fastcgi repository
   command: rpm -ivh http://pkgs.repoforge.org/rpmforge-release/rpmforge-release-0.5.3-1.el6.rf.x86_64.rpm

--- a/roles/ceph-common/tasks/installs/install_rgw_on_redhat.yml
+++ b/roles/ceph-common/tasks/installs/install_rgw_on_redhat.yml
@@ -9,7 +9,7 @@
 - name: add special fastcgi repository key
   rpm_key:
     key: http://dag.wieers.com/rpm/packages/RPM-GPG-KEY.dag.txt
-    validate_certs: no
+    validate_certs: "{{ validate_certs }}"
 
 - name: add special fastcgi repository
   command: rpm -ivh http://pkgs.repoforge.org/rpmforge-release/rpmforge-release-0.5.3-1.el6.rf.x86_64.rpm

--- a/roles/ceph-common/tasks/installs/redhat_ceph_repository.yml
+++ b/roles/ceph-common/tasks/installs/redhat_ceph_repository.yml
@@ -3,28 +3,28 @@
   rpm_key:
     key: "{{ ceph_stable_key }}"
     state: present
-    validate_certs: no
+    validate_certs: "{{ validate_certs }}"
   when: ceph_stable
 
 - name: install the ceph development repository key
   rpm_key:
     key: "{{ ceph_dev_key }}"
     state: present
-    validate_certs: no
+    validate_certs: "{{ validate_certs }}"
   when: ceph_dev
 
 - name: install inktank ceph enterprise repository key
   rpm_key:
     key: "{{ ceph_stable_ice_temp_path }}/release.asc"
     state: present
-    validate_certs: no
+    validate_certs: "{{ validate_certs }}"
   when: ceph_stable_ice
 
 - name: install red hat storage repository key
   rpm_key:
     key: "{{ ceph_stable_rh_storage_repository_path }}/RPM-GPG-KEY-redhat-release"
     state: present
-    validate_certs: no
+    validate_certs: "{{ validate_certs }}"
   when:
     ceph_stable_rh_storage and
     ceph_stable_rh_storage_iso_install

--- a/roles/ceph-common/tasks/installs/redhat_ceph_repository.yml
+++ b/roles/ceph-common/tasks/installs/redhat_ceph_repository.yml
@@ -3,24 +3,28 @@
   rpm_key:
     key: "{{ ceph_stable_key }}"
     state: present
+    validate_certs: no
   when: ceph_stable
 
 - name: install the ceph development repository key
   rpm_key:
     key: "{{ ceph_dev_key }}"
     state: present
+    validate_certs: no
   when: ceph_dev
 
 - name: install inktank ceph enterprise repository key
   rpm_key:
     key: "{{ ceph_stable_ice_temp_path }}/release.asc"
     state: present
+    validate_certs: no
   when: ceph_stable_ice
 
 - name: install red hat storage repository key
   rpm_key:
     key: "{{ ceph_stable_rh_storage_repository_path }}/RPM-GPG-KEY-redhat-release"
     state: present
+    validate_certs: no
   when:
     ceph_stable_rh_storage and
     ceph_stable_rh_storage_iso_install

--- a/roles/ceph-install/tasks/installs/install_rgw_on_redhat.yml
+++ b/roles/ceph-install/tasks/installs/install_rgw_on_redhat.yml
@@ -8,6 +8,7 @@
 
 - name: add special fastcgi repository key
   rpm_key:
+    validate_certs: no
     key: http://dag.wieers.com/rpm/packages/RPM-GPG-KEY.dag.txt
 
 - name: add special fastcgi repository

--- a/roles/ceph-install/tasks/installs/install_rgw_on_redhat.yml
+++ b/roles/ceph-install/tasks/installs/install_rgw_on_redhat.yml
@@ -8,7 +8,7 @@
 
 - name: add special fastcgi repository key
   rpm_key:
-    validate_certs: no
+    validate_certs: "{{ validate_certs }}"
     key: http://dag.wieers.com/rpm/packages/RPM-GPG-KEY.dag.txt
 
 - name: add special fastcgi repository

--- a/roles/ceph-install/tasks/installs/redhat_ceph_repository.yml
+++ b/roles/ceph-install/tasks/installs/redhat_ceph_repository.yml
@@ -3,26 +3,26 @@
   rpm_key:
     key: "{{ ceph_stable_key }}"
     state: present
-    validate_certs: no
+    validate_certs: "{{ validate_certs }}"
   when: ceph_stable
 
 - name: install the ceph development repository key
   rpm_key:
-    validate_certs: no
+    validate_certs: "{{ validate_certs }}"
     key: "{{ ceph_dev_key }}"
     state: present
   when: ceph_dev
 
 - name: install inktank ceph enterprise repository key
   rpm_key:
-    validate_certs: no
+    validate_certs: "{{ validate_certs }}"
     key: "{{ ceph_stable_ice_temp_path }}/release.asc"
     state: present
   when: ceph_stable_ice
 
 - name: install red hat storage repository key
   rpm_key:
-    validate_certs: no
+    validate_certs: "{{ validate_certs }}"
     key: "{{ ceph_stable_rh_storage_repository_path }}/RPM-GPG-KEY-redhat-release"
     state: present
   when:

--- a/roles/ceph-install/tasks/installs/redhat_ceph_repository.yml
+++ b/roles/ceph-install/tasks/installs/redhat_ceph_repository.yml
@@ -3,22 +3,26 @@
   rpm_key:
     key: "{{ ceph_stable_key }}"
     state: present
+    validate_certs: no
   when: ceph_stable
 
 - name: install the ceph development repository key
   rpm_key:
+    validate_certs: no
     key: "{{ ceph_dev_key }}"
     state: present
   when: ceph_dev
 
 - name: install inktank ceph enterprise repository key
   rpm_key:
+    validate_certs: no
     key: "{{ ceph_stable_ice_temp_path }}/release.asc"
     state: present
   when: ceph_stable_ice
 
 - name: install red hat storage repository key
   rpm_key:
+    validate_certs: no
     key: "{{ ceph_stable_rh_storage_repository_path }}/RPM-GPG-KEY-redhat-release"
     state: present
   when:

--- a/roles/contiv_cluster/tasks/main.yml
+++ b/roles/contiv_cluster/tasks/main.yml
@@ -21,7 +21,7 @@
 
 - name: download clusterm
   get_url:
-    validate_certs: no
+    validate_certs: "{{ validate_certs }}"
     url: https://github.com/contiv/cluster/releases/download/v0.0.0-01-05-2016.22-21-32.UTC/cluster-v0.0.0-01-05-2016.22-21-32.UTC.tar.bz2
     dest: /tmp/cluster-v0.0.0-01-05-2016.22-21-32.UTC.tar.bz2
     force: no

--- a/roles/contiv_network/tasks/main.yml
+++ b/roles/contiv_network/tasks/main.yml
@@ -19,7 +19,7 @@
 
 - name: download netmaster and netplugin
   get_url:
-    validate_certs: no
+    validate_certs: "{{ validate_certs }}"
     url: https://github.com/contiv/netplugin/releases/download/v0.0.0-12-11-2015.20-54-40.UTC/netplugin-v0.0.0-12-11-2015.20-54-40.UTC.tar.bz2
     dest: /tmp/contivnet.tar.bz2
 

--- a/roles/contiv_network/tasks/ovs.yml
+++ b/roles/contiv_network/tasks/ovs.yml
@@ -15,7 +15,7 @@
 
 - name: download ovs binaries (debian)
   get_url:
-    validate_certs: no
+    validate_certs: "{{ validate_certs }}"
     dest: "{{ item.dest }}"
     url: "{{ item.url }}"
   with_items:

--- a/roles/contiv_storage/tasks/main.yml
+++ b/roles/contiv_storage/tasks/main.yml
@@ -3,7 +3,7 @@
 
 - name: download storage service binaries
   get_url:
-    validate_certs: no
+    validate_certs: "{{ validate_certs }}"
     url: https://github.com/contiv/volplugin/releases/download/v0.0.0-12-14-2015.00-48-49.UTC/volplugin-v0.0.0-12-14-2015.00-48-49.UTC.tar.bz2
     dest: /tmp/contivvol.tar.bz2
 

--- a/roles/dev/tasks/os_agnostic_tasks.yml
+++ b/roles/dev/tasks/os_agnostic_tasks.yml
@@ -1,6 +1,6 @@
 - name: download Golang v1.5.2
   get_url:
-    validate_certs: no
+    validate_certs: "{{ validate_certs }}"
     url: https://storage.googleapis.com/golang/go1.5.2.linux-amd64.tar.gz
     dest: /tmp/go1.5.2.linux-amd64.tar.gz
     force: no
@@ -23,7 +23,7 @@
 
 - name: download packer
   get_url:
-    validate_certs: no
+    validate_certs: "{{ validate_certs }}"
     url: https://releases.hashicorp.com/packer/0.8.6/packer_0.8.6_linux_amd64.zip
     dest: /tmp/packer_0.8.6_linux_amd64.zip
     force: no

--- a/roles/dev/tasks/redhat_tasks.yml
+++ b/roles/dev/tasks/redhat_tasks.yml
@@ -1,6 +1,6 @@
 - name: download VBox (redhat)
   get_url:
-    validate_certs: no
+    validate_certs: "{{ validate_certs }}"
     url: http://download.virtualbox.org/virtualbox/5.0.12/VirtualBox-5.0-5.0.12_104815_el7-1.x86_64.rpm
     dest: /tmp/VirtualBox-5.0-5.0.12_104815_el7-1.x86_64.rpm
     force: no
@@ -13,7 +13,7 @@
 
 - name: download vagrant (redhat)
   get_url:
-    validate_certs: no
+    validate_certs: "{{ validate_certs }}"
     url: https://releases.hashicorp.com/vagrant/1.8.1/vagrant_1.8.1_x86_64.rpm
     dest: /tmp/vagrant_1.8.1_x86_64.rpm
     force: no

--- a/roles/dev/tasks/ubuntu_tasks.yml
+++ b/roles/dev/tasks/ubuntu_tasks.yml
@@ -1,6 +1,6 @@
 - name: download VBox (debian)
   get_url:
-    validate_certs: no
+    validate_certs: "{{ validate_certs }}"
     url: http://download.virtualbox.org/virtualbox/5.0.12/virtualbox-5.0_5.0.12-104815~Ubuntu~trusty_amd64.deb
     dest: /tmp/virtualbox-5.0_5.0.12-104815~Ubuntu~trusty_amd64.deb
     force: no
@@ -13,7 +13,7 @@
 
 - name: download vagrant (debian)
   get_url:
-    validate_certs: no
+    validate_certs: "{{ validate_certs }}"
     url: https://releases.hashicorp.com/vagrant/1.8.1/vagrant_1.8.1_x86_64.deb
     dest: /tmp/vagrant_1.8.1_x86_64.deb
     force: no

--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -3,7 +3,7 @@
 
 - name: download etcd v2.1.1
   get_url:
-    validate_certs: no
+    validate_certs: "{{ validate_certs }}"
     url: https://github.com/coreos/etcd/releases/download/v2.1.1/etcd-v2.1.1-linux-amd64.tar.gz
     dest: /tmp/etcd-v2.1.1-linux-amd64.tar.gz
     force: no

--- a/roles/serf/tasks/main.yml
+++ b/roles/serf/tasks/main.yml
@@ -3,7 +3,7 @@
 
 - name: download serf binary
   get_url:
-    validate_certs: no
+    validate_certs: "{{ validate_certs }}"
     url: https://dl.bintray.com/mitchellh/serf/0.6.4_linux_amd64.zip
     dest: /tmp/0.6.4_linux_amd64.zip
   tags:

--- a/roles/swarm/tasks/main.yml
+++ b/roles/swarm/tasks/main.yml
@@ -3,7 +3,7 @@
 
 - name: download and install swarm
   get_url:
-    validate_certs: no
+    validate_certs: "{{ validate_certs }}"
     url: https://cisco.box.com/shared/static/0txiq5h7282hraujk09eleoevptd5jpl
     dest: /usr/bin/swarm
     mode: u=rwx,g=rx,o=rx

--- a/site.yml
+++ b/site.yml
@@ -9,7 +9,7 @@
 #   service deployments like collins, sky-dns, ceph etc.
 - hosts: devtest
   sudo: true
-  environment: env
+  environment: '{{ env }}'
   roles:
   - { role: base }
   - { role: serf }
@@ -17,7 +17,7 @@
 
 - hosts: volplugin-test
   sudo: true
-  environment: env
+  environment: '{{ env }}'
   roles: 
   - { role: base }
   - { role: vagrant }
@@ -33,7 +33,7 @@
 # to bootstrap the cluster by starting cluster manager and inventory database (collins)
 - hosts: cluster-control
   sudo: true
-  environment: env
+  environment: '{{ env }}'
   roles:
   - { role: base }
   - { role: docker, etcd_client_port1: 2379 }
@@ -43,7 +43,7 @@
 # logic of the infra services
 - hosts: service-master
   sudo: true
-  environment: env
+  environment: '{{ env }}'
   roles:
   - { role: base }
   - { role: ucarp }
@@ -59,7 +59,7 @@
 # logic of the infra services.
 - hosts: service-worker
   sudo: true
-  environment: env
+  environment: '{{ env }}'
   roles:
   - { role: base }
   - { role: docker }
@@ -72,7 +72,7 @@
 # netplugin-node hosts set up netmast/netplugin in a cluster
 - hosts: netplugin-node
   sudo: true
-  environment: env
+  environment: '{{ env }}'
   roles:
   - { role: base }
   - { role: etcd, run_as: master }


### PR DESCRIPTION
- workaround for python-crypto install failure (fixes #28 )
  - There seems a know issue (https://bugs.centos.org/view.php?id=9896&nbn=2) with installing python-crypto package that is needed for ansible. And it interferes with ansible's yum installation.

~~\- Also set the ansible version to be installed 1.9~~
~~\- This prevents auto upgrade to 2.0 which is not backward compatible with our playbooks.~~
- turned off certification validation to work behind proxy. (also fixes https://github.com/contiv/cluster/issues/34)
- fixed the syntax for setting environment (fixes #32 )

This fixes some of the issues that I hit while trying to vendor in ansible in build and volplugin. 

/cc @erikh 
