### PR TITLE
remove dependence from pip

### DIFF
--- a/roles/base/tasks/os_agnostic_tasks.yml
+++ b/roles/base/tasks/os_agnostic_tasks.yml
@@ -6,11 +6,3 @@
 
 - name: install consul
   shell: "chdir=/tmp creates=/usr/bin/consul unzip /tmp/consul.zip && mv /tmp/consul /usr/bin"
-
-#NOTE: Upgrade pip to latest which is needed for correct installation of docker-compose
-#XXX: This messes with the python packages already installed causing any yum/apt
-#re-run to fail subsequently. We need a different way to update pip.
-- name: upgrade pip
-  pip:
-    name: pip
-    extra_args: "--upgrade"

--- a/roles/base/tasks/redhat_tasks.yml
+++ b/roles/base/tasks/redhat_tasks.yml
@@ -24,7 +24,6 @@
     - perl
     - librbd1-devel
     - lshw
-    - python-pip
     - python-requests # XXX required by ceph repo, but it has a bad package on it
 
 - name: install and start ntp

--- a/roles/base/tasks/ubuntu_tasks.yml
+++ b/roles/base/tasks/ubuntu_tasks.yml
@@ -18,7 +18,6 @@
     - perl
     - librbd-dev
     - lshw
-    - python-pip
 
 - name: add ansible apt repository (debian)
   apt_repository:

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -45,7 +45,19 @@
   tags:
     - prebake-for-dev
 
-- name: install docker-compose
-  pip: name=docker-compose state=latest extra_args=--upgrade
+- name: check docker-compose version
+  shell: docker-compose --version
+  register: docker_compose_version
+  ignore_errors: yes
+  tags:
+    - prebake-for-dev
+
+- name: download and install docker-compose
+  get_url:
+    validate_certs: "{{ validate_certs }}"
+    url: https://github.com/docker/compose/releases/download/1.5.2/docker-compose-{{ ansible_system }}-{{ ansible_userspace_architecture }}
+    dest: /usr/bin/docker-compose
+    mode: u=rwx,g=rx,o=rx
+  when: docker_compose_version.stdout != "docker-compose version 1.5.2, build 7240ff3"
   tags:
     - prebake-for-dev


### PR DESCRIPTION
mixing pip and os specific package manager runs a risk of both stepping on each other's package states. This commit moves docker-compose installation to be done using the release url as prescribed here https://docs.docker.com/compose/install/

This allows us to remove pip installation altogether.

Fixes #37 and also related issues that were seen recently in one of the setups that I believe @DivyaVavili debugged. The resolution/work-around was to uninstall and re-install pip.
