### PR TITLE
use control_interface as variable for interface carrying control traffic

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -1,17 +1,19 @@
 ---
 # Variables here are applicable to all host groups
 
+# ceph specific variables
 ceph_stable: true # use ceph stable branch
 cephx: true
 cephx_require_signatures: false # Kernel RBD does NOT support signatures!
 cephx_cluster_require_signatures: true
 cephx_service_require_signatures: false
-
-node_name: "{{ inventory_hostname }}"
-node_addr: "{{ hostvars[inventory_hostname]['ansible_' + monitor_interface]['ipv4']['address'] }}"
-
 crush_location: false
 osd_crush_location: "'root={{ ceph_crush_root }} rack={{ ceph_crush_rack }} host={{ ansible_hostname }}'"
+monitor_interface: control_interface
+
+#host variables
+node_name: "{{ inventory_hostname }}"
+node_addr: "{{ hostvars[inventory_hostname]['ansible_' + control_interface]['ipv4']['address'] }}"
 
 validate_certs: "yes"
 
@@ -20,4 +22,4 @@ validate_certs: "yes"
 
 # env:
 # service_vip:
-# monitor_interface:
+# control_interface:

--- a/roles/etcd/vars/main.yml
+++ b/roles/etcd/vars/main.yml
@@ -6,7 +6,7 @@ etcd_client_port2: 4001
 etcd_peer_port1: 2380
 etcd_peer_port2: 7001
 etcd_peers_group: "service-master"
-etcd_peer_interface: "{{ monitor_interface }}"
+etcd_peer_interface: "{{ control_interface }}"
 etcd_init_cluster: true
 
 

--- a/roles/ucarp/templates/ucarp.sh.j2
+++ b/roles/ucarp/templates/ucarp.sh.j2
@@ -10,8 +10,8 @@ set -x -e
     
 case $1 in
 start)
-    /sbin/ucarp --shutdown --interface={{ monitor_interface }} \
-        --srcip={{ hostvars[inventory_hostname]['ansible_' + monitor_interface]['ipv4']['address'] }} \
+    /sbin/ucarp --shutdown --interface={{ control_interface }} \
+        --srcip={{ hostvars[inventory_hostname]['ansible_' + control_interface]['ipv4']['address'] }} \
         --vhid=1 --pass=cluster_secret --addr={{ service_vip }} \
         --upscript="/usr/bin/ucarp/vip_up.sh" --downscript="/usr/bin/ucarp/vip_down.sh"
     ;;


### PR DESCRIPTION
monitor_interface variable is ceph specific. This change introduces a new host variable called control_interface to depict the interface used as control interface on hosts deploying contiv services and it's dependencies like etcd, swarm, ucarp etc. control_interface replaces monitor_interface in contiv specific plays.

/cc @DivyaVavili as this may affect your netplugin installer work.
