### PR TITLE
Tasks to bring up netplugin in ACI mode

### DIFF
--- a/roles/contiv_network/defaults/main.yml
+++ b/roles/contiv_network/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+
+# Role defaults for contiv_network
+# NOTE: Role defaults have a lower priority than inventory vars.
+# Include variables which need to be overridden by inventory vars here.
+
+contiv_network_mode: "standalone" # Accepted values: standalone, aci

--- a/roles/contiv_network/files/aci-gw.service
+++ b/roles/contiv_network/files/aci-gw.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Contiv ACI gw
+After=auditd.service systemd-user-sessions.service time-sync.target docker.service
+
+[Service]
+ExecStart=/usr/bin/aci_gw.sh start
+ExecStop=/usr/bin/aci_gw.sh stop
+KillMode=control-group
+Restart=on-failure
+RestartSec=10

--- a/roles/contiv_network/tasks/aci_tasks.yml
+++ b/roles/contiv_network/tasks/aci_tasks.yml
@@ -1,0 +1,28 @@
+# These tasks are run when contiv_network_mode is set to aci
+
+- name: check aci-gw container image
+  shell: docker inspect contiv/aci-gw
+  register: docker_aci_inspect_result
+  ignore_errors: yes
+  run_once: true
+
+- name: pull aci-gw container
+  shell: docker pull contiv/aci-gw
+  when: "'No such image' in docker_aci_inspect_result.stderr"
+  run_once: true
+
+- name: copy shell script for starting aci-gw
+  template: src=aci_gw.j2 dest=/usr/bin/aci_gw.sh mode=u=rwx,g=rx,o=rx
+  run_once: true
+
+- name: copy systemd units for aci-gw
+  copy: src=aci-gw.service dest=/etc/systemd/system/aci-gw.service
+  run_once: true
+
+- name: start aci-gw container
+  service: name=aci-gw state=started
+  run_once: true
+
+- name: set aci mode
+  shell: contivctl global set -nwinfra aci
+  run_once: true

--- a/roles/contiv_network/tasks/main.yml
+++ b/roles/contiv_network/tasks/main.yml
@@ -68,3 +68,6 @@
   args:
     chdir: /usr/bin/
     creates: contivctl
+
+- include: aci_tasks.yml
+  when: (run_as == "master") and (contiv_network_mode == "aci")

--- a/roles/contiv_network/templates/aci_gw.j2
+++ b/roles/contiv_network/templates/aci_gw.j2
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+usage="$0 start"
+if [ $# -ne 1 ]; then
+    echo USAGE: $usage
+    exit 1
+fi
+
+case $1 in
+start)
+    set -e
+
+    /usr/bin/docker run --net=host \
+    -e "APIC_URL: {{ apic_url }}" \
+    -e "APIC_USERNAME: {{ apic_username }}" \
+    -e "APIC_PASSWORD: {{ apic_password }}" \
+    -e "APIC_LEAF_NODE: {{ apic_leaf_nodes }}" \
+    --name=contiv-aci-gw \
+    contiv/aci-gw
+    ;;
+
+stop)
+    # don't stop on error
+    /usr/bin/docker stop contiv-aci-gw
+    /usr/bin/docker rm contiv-aci-gw
+    ;;
+
+*)
+    echo USAGE: $usage
+    exit 1
+    ;;
+esac

--- a/roles/contiv_network/templates/netplugin.j2
+++ b/roles/contiv_network/templates/netplugin.j2
@@ -1,1 +1,1 @@
-NETPLUGIN_ARGS=""
+NETPLUGIN_ARGS='-docker-plugin -vlan-if {{netplugin_if}} -vtep-ip {{node_addr}}'

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -61,3 +61,28 @@
   when: docker_compose_version.stdout != "docker-compose version 1.5.2, build 7240ff3"
   tags:
     - prebake-for-dev
+
+- name: check contiv-compose version
+  shell: contiv-compose --version
+  register: contiv_compose_version
+  ignore_errors: yes
+  tags:
+    - prebake-for-dev
+
+- name: download contiv-compose
+  get_url:
+    validate_certs: "{{ validate_certs }}"
+    url: https://cisco.box.com/shared/static/eagplmveetdmwn7u2uwadna07l1m8t3s.bz2
+    dest: /tmp/contiv-compose.bz2
+  when: docker_compose_version.stdout != "libcompose-cli version 0.0.0-dev (4c0c2dd)"
+  tags:
+    - prebake-for-dev
+
+- name: install contiv-compose
+  shell: tar vxjf /tmp/contiv-compose.bz2
+  args:
+    chdir: /usr/bin/
+    creates: contiv-compose
+  when: docker_compose_version.stdout != "libcompose-cli version 0.0.0-dev (4c0c2dd)"
+  tags:
+    - prebake-for-dev


### PR DESCRIPTION
The current set of changes bring up netplugin-node in ACI mode when aci_mode is set to true. As part of this, the following changes are made:
- Launch aci-gw container with respective environment variables
- Replace docker-compose with contiv version of docker-compose
