### PR TITLE
make python crypto workaround task more generic

### DIFF
--- a/roles/base/tasks/redhat_tasks.yml
+++ b/roles/base/tasks/redhat_tasks.yml
@@ -35,8 +35,8 @@
   ignore_errors: yes
 
 - name: remove python crypt egg file to work-around https://bugs.centos.org/view.php?id=9896&nbn=2
-  shell: rm -rf /usr/lib64/python2.7/site-packages/pycrypto-2.6.1-py2.7.egg-info
-  when: python_crypto_result.msg == "Error unpacking rpm package python-crypto-2.6.1-1.el7.centos.x86_64\n"
+  shell: rm -rf /usr/lib64/python2.7/site-packages/pycrypto-*.egg-info
+  when: '"Error unpacking rpm package python2-crypto-" in python_crypto_result.msg'
 
 - name: install ansible (redhat)
   yum: name=ansible state=present


### PR DESCRIPTION
@erikh PTAL. 

This fixes the issue that we recently addressed in volplugin (https://github.com/contiv/volplugin/pull/110) but now I am hitting in cluster-mgr while trying to pull in recent ansible there :)

Please note that I limited the fix to just making python-crypto string check more generic as the volplugin related fix has an issue with ansible installation failure under some other failure conditions as discussed here https://github.com/contiv/volplugin/pull/110#discussion_r50438273
