### PR TITLE
use a versioned collins image

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -45,6 +45,13 @@ Vagrant.configure(2) do |config|
                 node.vm.box = "box-cutter/ubuntu1504"
                 node.vm.box_version = "2.0.12"
             end
+
+            # set the vm's ram and cpu big enough for docker to run fine
+            node.vm.provider "virtualbox" do |vb|
+                vb.customize ['modifyvm', :id, '--memory', "4096"]
+                vb.customize ["modifyvm", :id, "--cpus", "2"]
+            end
+
             if ansible_groups["devtest"] == nil then
                 ansible_groups["devtest"] = [ ]
             end

--- a/roles/contiv_cluster/tasks/main.yml
+++ b/roles/contiv_cluster/tasks/main.yml
@@ -12,7 +12,7 @@
     - prebake-for-dev
 
 - name: pull collins container image
-  shell: docker pull tumblr/collins
+  shell: docker pull {{ collins_image }}
   tags:
     - prebake-for-dev
 

--- a/roles/contiv_cluster/templates/collins.j2
+++ b/roles/contiv_cluster/templates/collins.j2
@@ -10,11 +10,12 @@ case $1 in
 start)
     set -e
 
-    /usr/bin/docker run -t -p {{ collins_host_port }}:{{ collins_guest_port }} --name collins tumblr/collins
+    /usr/bin/docker run -t -p {{ collins_host_port }}:{{ collins_guest_port }} \
+        --name collins {{ collins_image }}
     ;;
 
 stop)
-    # don't stop on error
+    # skipping `set -e` as we shouldn't stop on error
     /usr/bin/docker stop collins
     /usr/bin/docker rm collins
     ;;

--- a/roles/contiv_cluster/vars/main.yml
+++ b/roles/contiv_cluster/vars/main.yml
@@ -1,5 +1,6 @@
 ---
 # role variable for the cluster manager service
 
+collins_image: contiv/collins:01_25_2016
 collins_host_port: 9000
 collins_guest_port: 9000


### PR DESCRIPTION
the tumbler's docker image is always tagged latest and is not versioned, so I have created a tagged image in contiv's repo that we can use in short term.
