### PR TITLE
define ceph_stable_ice_temp_path variable

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -10,6 +10,7 @@ cephx_service_require_signatures: false
 crush_location: false
 osd_crush_location: "'root={{ ceph_crush_root }} rack={{ ceph_crush_rack }} host={{ ansible_hostname }}'"
 monitor_interface: control_interface
+ceph_stable_ice_temp_path: /opt/ICE/ceph-repo/
 
 #host variables
 node_name: "{{ inventory_hostname }}"


### PR DESCRIPTION
otherwise the `ceph-install` play fails when run on hosts with ansiblev2

/cc @erikh . PTAL. I am not very sure if this is right way to address this undefined variable. For more context on the failure have a look at this failed run `http://contiv.ngrok.io/job/Ansible_CI/41/console`
