### PR TITLE
fix etcd cleanup to remove the temp file

### DIFF
--- a/cleanup.yml
+++ b/cleanup.yml
@@ -6,6 +6,9 @@
 - hosts: all
   sudo: true
   tasks:
+    - include_vars: roles/{{ item }}/vars/main.yml
+      with_items:
+      - "etcd"
     - include: roles/contiv_network/tasks/cleanup.yml
       ignore_errors: yes
     - include: roles/contiv_storage/tasks/cleanup.yml

--- a/roles/etcd/tasks/cleanup.yml
+++ b/roles/etcd/tasks/cleanup.yml
@@ -3,3 +3,6 @@
 
 - name: stop etcd
   service: name=etcd state=stopped
+
+- name: remove the temp etcd file
+  file: name={{ etcd_tmp_filename }} state=absent

--- a/roles/etcd/templates/etcd.j2
+++ b/roles/etcd/templates/etcd.j2
@@ -35,8 +35,8 @@ start)
     {% endmacro -%}
 
     {% macro init_cluster() -%}
-    if [ ! -f /var/tmp/etcd.existing ]; then
-        touch /var/tmp/etcd.existing
+    if [ ! -f {{ etcd_tmp_filename }} ]; then
+        touch {{ etcd_tmp_filename }}
         export ETCD_INITIAL_CLUSTER_STATE=new
         export ETCD_INITIAL_CLUSTER="
         {%- for host in groups[etcd_peers_group] -%}
@@ -62,7 +62,9 @@ start)
             {% set peer_addr=hostvars[peers[0]]['ansible_' + etcd_peer_interface]['ipv4']['address'] -%}
             {{ add_member(peer_addr=peer_addr) }}
         {%- else -%}
-        echo "==> no peer found, single member cluster?"
+        {# This condition shall not arise, so fail early #}
+        echo "==> no peer found, failing now"
+        exit 1
         {% endif -%}
     fi
     {% endmacro -%}
@@ -74,7 +76,7 @@ start)
     # on master nodes, if the cluster is being initialized for first time then initialize it
     {{ init_cluster() }}
     {% else -%}
-    # if a new master node is being commissioned then add it to exisitng cluster
+    # if a new master node is being commissioned then add it to exisiting cluster
     {{ add_member(peer_addr=etcd_master_addr) }}
     {% endif -%}
 

--- a/roles/etcd/vars/main.yml
+++ b/roles/etcd/vars/main.yml
@@ -8,7 +8,7 @@ etcd_peer_port2: 7001
 etcd_peers_group: "service-master"
 etcd_peer_interface: "{{ control_interface }}"
 etcd_init_cluster: true
-
+etcd_tmp_filename: "/tmp/etcd.existing"
 
 # following variables are used in one or more roles, but have no good default value to pick from.
 # Leaving them as commented so that playbooks can fail early with variable not defined error.


### PR DESCRIPTION
This fixes #47 

This is a lengthy description for a seemingly simple fix. But I thought it will be good to capture it somewhere for my memory :)

**issue description**:
We use following two scenarios to build a etcd cluster (run for master nodes):
- **init**
  - this is triggered when we bootstrap a cluster with one or more nodes. As of now we add one node at a time in cluster-mgr but multiple nodes are added in demo and test environments.
- **add member**
  - this is triggered when a new member needs to be added to existing cluster

The above scenarios are in ansible and are intentionally kept simple. More complex cases are expected to be handled by an higher level entity like cluster-mgr and/or the netplugin-installer in short term.

Now, as part of **init** we create a temporary file when etcd is provisioned. This file is useful if we are going to manually stop/restart etcd on just this node (usually as part of tests (example, volplugin systemtests) and also when we know we have brought up a cluster of multiple nodes (i.e. the `else` clause of generated bash script handles a cluster of more than one node). However, for cluster-mgr and installer workflows we will use `cleanup.yml` file first to decommission/cleanup a node.

Given the above, when a node is decommissioned (using the `cleanup.yml`) we were just stopping the etcd service and not removing this file. That causes etcd to fail since the file exists and the `else` clause of the generated bash script cannot (should not) handle a new cluster init.

**Fix:**
the cleanup should remove the temporary file, so that when we provision it again (using either one of scenarios described above) this file is recreated appropriately and doesn't interfere.

Note that doesn't change anything wrt the test setups which will continue to work as is as they are not expected to use `cleanup.yml`  
