### PR TITLE
ansible task for bash autocompletion support for netctl cli

### DIFF
--- a/roles/base/tasks/redhat_tasks.yml
+++ b/roles/base/tasks/redhat_tasks.yml
@@ -25,6 +25,7 @@
     - librbd1-devel
     - lshw
     - python-requests # XXX required by ceph repo, but it has a bad package on it
+    - bash-completion
 
 - name: install and start ntp
   shell: systemctl enable ntpd

--- a/roles/base/tasks/ubuntu_tasks.yml
+++ b/roles/base/tasks/ubuntu_tasks.yml
@@ -18,6 +18,7 @@
     - perl
     - librbd-dev
     - lshw
+    - bash-completion
 
 - name: add ansible apt repository (debian)
   apt_repository:

--- a/roles/contiv_network/defaults/main.yml
+++ b/roles/contiv_network/defaults/main.yml
@@ -5,3 +5,4 @@
 # Include variables which need to be overridden by inventory vars here.
 
 contiv_network_mode: "standalone" # Accepted values: standalone, aci
+netplugin_mode: "docker" # Accepted values: docker, kubernetes

--- a/roles/contiv_network/tasks/main.yml
+++ b/roles/contiv_network/tasks/main.yml
@@ -23,11 +23,22 @@
     url: https://github.com/contiv/netplugin/releases/download/v0.1-01-28-2016.03-55-05.UTC/netplugin-v0.1-01-28-2016.03-55-05.UTC.tar.bz2
     dest: /tmp/contivnet.tar.bz2
 
+- name: ensure netplugin directory exists
+  file: path=/usr/bin/contiv/netplugin state=directory
+
 - name: install netmaster and netplugin
   shell: tar vxjf /tmp/contivnet.tar.bz2
   args:
-    chdir: /usr/bin/
+    chdir: /usr/bin/contiv/netplugin
     creates: netmaster
+
+- name: create links for netplugin binaries
+  file: src=/usr/bin/contiv/netplugin/{{ item }} dest=/usr/bin/{{ item }} state=link
+  with_items:
+    - netctl
+    - netmaster
+    - netplugin
+    - contivk8s
 
 - name: copy environment file for netplugin
   template: src=netplugin.j2 dest=/etc/default/netplugin
@@ -36,7 +47,7 @@
   copy: src=netplugin.service dest=/etc/systemd/system/netplugin.service
 
 - name: copy bash auto complete file for netctl
-  shell: sudo cp /usr/bin/contrib/completion/bash/netctl /etc/bash_completion.d/ && sudo rm -rf /usr/bin/contrib
+  file: src=/usr/bin/contiv/netplugin/contrib/completion/bash/netctl dest=/etc/bash_completion.d/netctl state=link
 
 - name: start netplugin
   shell: systemctl daemon-reload && systemctl start netplugin

--- a/roles/contiv_network/tasks/main.yml
+++ b/roles/contiv_network/tasks/main.yml
@@ -20,7 +20,7 @@
 - name: download netmaster and netplugin
   get_url:
     validate_certs: "{{ validate_certs }}"
-    url: https://github.com/contiv/netplugin/releases/download/v0.0.0-12-11-2015.20-54-40.UTC/netplugin-v0.0.0-12-11-2015.20-54-40.UTC.tar.bz2
+    url: https://github.com/contiv/netplugin/releases/download/v0.1-01-28-2016.03-55-05.UTC/netplugin-v0.1-01-28-2016.03-55-05.UTC.tar.bz2
     dest: /tmp/contivnet.tar.bz2
 
 - name: install netmaster and netplugin
@@ -34,6 +34,9 @@
 
 - name: copy systemd units for netplugin
   copy: src=netplugin.service dest=/etc/systemd/system/netplugin.service
+
+- name: copy bash auto complete file for netctl
+  shell: sudo cp /usr/bin/contrib/completion/bash/netctl /etc/bash_completion.d/ && sudo rm -rf /usr/bin/contrib
 
 - name: start netplugin
   shell: systemctl daemon-reload && systemctl start netplugin

--- a/roles/contiv_network/templates/netplugin.j2
+++ b/roles/contiv_network/templates/netplugin.j2
@@ -1,1 +1,1 @@
-NETPLUGIN_ARGS='-docker-plugin -vlan-if {{netplugin_if}} -vtep-ip {{node_addr}}'
+NETPLUGIN_ARGS='-plugin-mode {{netplugin_mode}} -vlan-if {{netplugin_if}} -vtep-ip {{node_addr}}'


### PR DESCRIPTION
- install bash-completion package via yum/apt. This is added to the existing
  base role.
- updated the netplugin tar link to the latest release. The tar now has a
  contrib/completion/bash/netctl packaged in it.
- copy the packaged netctl file to /etc/bash_completion.d This needs sudo
  access.
