### PR TITLE
Fixing aci service and mode setup

### DIFF
--- a/roles/contiv_network/tasks/aci_tasks.yml
+++ b/roles/contiv_network/tasks/aci_tasks.yml
@@ -24,5 +24,5 @@
   run_once: true
 
 - name: set aci mode
-  shell: contivctl global set -nwinfra aci
+  shell: contivctl net global set --fabric-mode aci
   run_once: true

--- a/roles/contiv_network/tasks/main.yml
+++ b/roles/contiv_network/tasks/main.yml
@@ -73,12 +73,12 @@
 - name: download contivctl
   get_url:
     validate_certs: "{{ validate_certs }}"
-    url: https://github.com/contiv/contivctl/releases/download/v0.0.0-01-14-2016.01-27-38.UTC/contivctl-v0.0.0-01-14-2016.01-27-38.UTC.tar.bz2
-    dest: /tmp/contivctl-v0.0.0-01-14-2016.01-27-38.UTC.tar.bz2
+    url: https://github.com/contiv/contivctl/releases/download/v0.0.0-01-31-2016.17-56-53.UTC/contivctl-v0.0.0-01-31-2016.17-56-53.UTC.tar.bz2
+    dest: /tmp/contivctl-v0.0.0-01-31-2016.17-56-53.UTC.tar.bz2
     force: no
 
 - name: install contivctl
-  shell: tar vxjf /tmp/contivctl-v0.0.0-01-14-2016.01-27-38.UTC.tar.bz2
+  shell: tar vxjf /tmp/contivctl-v0.0.0-01-31-2016.17-56-53.UTC.tar.bz2
   args:
     chdir: /usr/bin/
     creates: contivctl

--- a/roles/contiv_network/templates/aci_gw.j2
+++ b/roles/contiv_network/templates/aci_gw.j2
@@ -11,10 +11,10 @@ start)
     set -e
 
     /usr/bin/docker run --net=host \
-    -e "APIC_URL: {{ apic_url }}" \
-    -e "APIC_USERNAME: {{ apic_username }}" \
-    -e "APIC_PASSWORD: {{ apic_password }}" \
-    -e "APIC_LEAF_NODE: {{ apic_leaf_nodes }}" \
+    -e "APIC_URL={{ apic_url }}" \
+    -e "APIC_USERNAME={{ apic_username }}" \
+    -e "APIC_PASSWORD={{ apic_password }}" \
+    -e "APIC_LEAF_NODE={{ apic_leaf_nodes }}" \
     --name=contiv-aci-gw \
     contiv/aci-gw
     ;;


### PR DESCRIPTION
Fixing service template for aci
Adding netctl command to setup aci mode as contivctl is not updated to take global commands

NOTE: Please merge after PR #52 as this requires the latest netplugin release
