### PR TITLE
changes to bring in ucp based swarm stack

### DIFF
--- a/cleanup.yml
+++ b/cleanup.yml
@@ -9,6 +9,9 @@
     - include_vars: roles/{{ item }}/vars/main.yml
       with_items:
       - "etcd"
+    - include_vars: roles/{{ item }}/defaults/main.yml
+      with_items:
+      - "ucp"
     - include: roles/contiv_network/tasks/cleanup.yml
       ignore_errors: yes
     - include: roles/contiv_storage/tasks/cleanup.yml
@@ -16,6 +19,8 @@
     - include: roles/contiv_cluster/tasks/cleanup.yml
       ignore_errors: yes
     - include: roles/swarm/tasks/cleanup.yml
+      ignore_errors: yes
+    - include: roles/ucp/tasks/cleanup.yml
       ignore_errors: yes
     - include: roles/docker/tasks/cleanup.yml
       ignore_errors: yes

--- a/roles/dev/meta/main.yml
+++ b/roles/dev/meta/main.yml
@@ -15,6 +15,7 @@ dependencies:
 - { role: etcd }
 - { role: docker }
 - { role: swarm }
+- { role: ucp }
 - { role: contiv_cluster }
 - { role: contiv_network }
 - { role: contiv_storage }

--- a/roles/scheduler_stack/defaults/main.yml
+++ b/roles/scheduler_stack/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+# Role defaults for contiv_scheduler
+
+scheduler_provider: "native-swarm" # Accepted values: native-swarm, ucp-swarm

--- a/roles/scheduler_stack/meta/main.yml
+++ b/roles/scheduler_stack/meta/main.yml
@@ -1,0 +1,7 @@
+---
+# This role contains tasks for configuring and starting the scheduler stacks
+# like native-swarm, ucp-swarm, k8s, mesos etc
+
+dependencies:
+- { role: swarm, when: scheduler_provider == "native-swarm" }
+- { role: ucp, when: scheduler_provider == "ucp-swarm" }

--- a/roles/swarm/templates/swarm.j2
+++ b/roles/swarm/templates/swarm.j2
@@ -9,8 +9,6 @@ fi
 case $1 in
 start)
     echo starting swarm as {{ run_as }} on {{ node_name }}[{{ node_addr }}]
-    # XXX: we run etcd as master every where so it is fine to use the node-address for etcd, revisit this once we have
-    # etcd as master only on a subset of nodes
     if [[ "{{ run_as }}" == "master" ]]; then
         /usr/bin/swarm join --advertise={{ node_addr }}:{{ docker_api_port }} etcd://{{ node_addr }}:{{ etcd_client_port1 }} &
         /usr/bin/swarm manage -H tcp://{{ node_addr }}:{{ swarm_api_port }} etcd://{{ node_addr }}:{{ etcd_client_port1 }}

--- a/roles/ucp/defaults/main.yml
+++ b/roles/ucp/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+# Role defaults for ucp
+
+ucp_version: "0.7.1"
+ucp_local_dir: "fetch/ucp"
+ucp_remote_dir: "/tmp"
+ucp_instance_id_file: "ucp-instance-id"
+ucp_fingerprint_file: "ucp-fingerprint"
+ucp_fifo_file: "ucp-fifo"

--- a/roles/ucp/files/ucp.service
+++ b/roles/ucp/files/ucp.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Ucp
+After=auditd.service systemd-user-sessions.service time-sync.target docker.service
+
+[Service]
+ExecStart=/usr/bin/ucp.sh start
+ExecStop=/usr/bin/ucp.sh stop
+KillMode=control-group

--- a/roles/ucp/tasks/cleanup.yml
+++ b/roles/ucp/tasks/cleanup.yml
@@ -1,0 +1,12 @@
+---
+# This play contains tasks for cleaning up ucp
+
+- name: stop ucp
+  service: name=ucp state=stopped
+
+- name: cleanup ucp files from remote
+  file: name="{{ ucp_remote_dir }}/{{ item }}" state=absent
+  with_items:
+    - "{{ ucp_fingerprint_file }}"
+    - "{{ ucp_instance_id_file }}"
+    - "{{ ucp_fifo_file }}"

--- a/roles/ucp/tasks/main.yml
+++ b/roles/ucp/tasks/main.yml
@@ -1,0 +1,54 @@
+---
+# This role contains tasks for configuring and starting the swarm stack using ucp
+
+- name: download and install ucp images
+  shell: >
+      docker run --rm -it \
+        --name ucp \
+        -v /var/run/docker.sock:/var/run/docker.sock \
+        docker/ucp \
+        images --image-version={{ ucp_version }}
+  tags:
+    - prebake-for-dev
+
+- name: copy the ucp files to worker nodes
+  copy:
+    src: "{{ ucp_local_dir }}/{{ item }}"
+    dest: "{{ ucp_remote_dir }}/{{ item }}"
+  with_items:
+    - "{{ ucp_fingerprint_file }}"
+    - "{{ ucp_instance_id_file }}"
+  when: run_as == "worker"
+
+- name: copy the ucp start/stop script
+  template: src=ucp.j2 dest=/usr/bin/ucp.sh mode=u=rwx,g=rx,o=rx
+
+- name: copy systemd units for ucp
+  copy: src=ucp.service dest=/etc/systemd/system/ucp.service
+
+- name: start ucp
+  service: name=ucp state=started
+
+- name: create a local fetch directory if it doesn't exist
+  local_action: file path={{ ucp_local_dir }} state=directory
+  when: run_as == "master"
+
+- name: wait for ucp files to be created, which ensures the service has started
+  wait_for:
+    path: "{{ ucp_remote_dir }}/{{ item }}"
+    state: present
+  with_items:
+    - "{{ ucp_fingerprint_file }}"
+    - "{{ ucp_instance_id_file }}"
+  when: run_as == "master"
+
+- name: fetch the ucp files from master nodes
+  fetch:
+    src: "{{ ucp_remote_dir }}/{{ item }}"
+    dest: "{{ ucp_local_dir }}/{{ item }}"
+    flat: yes
+    fail_on_missing: yes
+  with_items:
+    - "{{ ucp_fingerprint_file }}"
+    - "{{ ucp_instance_id_file }}"
+  when: run_as == "master"

--- a/roles/ucp/templates/ucp.j2
+++ b/roles/ucp/templates/ucp.j2
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+usage="$0 start|stop"
+if [ $# -ne 1 ]; then
+    echo USAGE: $usage
+    exit 1
+fi
+
+case $1 in
+start)
+    set -e
+
+    echo starting ucp as {{ run_as }} on {{ node_name }}[{{ node_addr }}]
+
+    if [[ "{{ run_as }}" == "master" ]]; then
+        out=$(/usr/bin/docker run --rm -t --name ucp \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            docker/ucp install --host-address={{ node_addr }} \
+              --image-version={{ ucp_version }})
+        echo ${out}
+
+        # copy out the instance ID
+        instanceId=$(echo ${out} | egrep -o 'UCP instance ID: [a-zA-Z0-9:_]*' | \
+            awk --field-separator='UCP instance ID: ' '{print $2}')
+        echo instance-id: $instanceId
+        echo ${instanceId} > "{{ ucp_remote_dir }}"/"{{ ucp_instance_id_file }}"
+
+        # copy out the fingerprint.
+        # XXX: we store the output in variable first than redirecting
+        # the output directly to file as we wait on this file to be created. So
+        # redirecting the output let's that task move forward even before the
+        # file contents have been written.
+        # XXX: we need a way for this fingerprint to stick around wherever
+        # contiv/cluster service is running. May be we can save this file on a
+        # distributed filesystem
+        out=$(/usr/bin/docker run --rm -t --name ucp \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            docker/ucp fingerprint)
+        echo ${out} > "{{ ucp_remote_dir }}"/"{{ ucp_fingerprint_file }}"
+    else
+        /usr/bin/docker run --rm -t --name ucp \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            -e UCP_ADMIN_USER="admin" -e UCP_ADMIN_PASSWORD="orca" \
+            docker/ucp join --host-address={{ node_addr }} \
+              --image-version={{ ucp_version }} \
+              --url="https://{{ service_vip }}:443" \
+              --fingerprint=`cat "{{ ucp_remote_dir }}"/"{{ ucp_fingerprint_file }}"`
+    fi
+
+    # now just sleep to keep the service up
+    mkfifo "{{ ucp_remote_dir }}"/"{{ ucp_fifo_file }}"
+    < "{{ ucp_remote_dir }}"/"{{ ucp_fifo_file }}"
+    ;;
+
+stop)
+    # don't `set -e` as we shouldn't stop on error
+
+    #stop the ucp containers and associated volumes
+    docker ps -a | grep 'ucp-' | awk '{print $1}' | xargs docker stop
+
+    #remove the ucp containers and associated volumes
+    docker ps -a | grep 'ucp-' | awk '{print $1}' | xargs docker rm -v
+
+    # XXX: do we need to uninstall ucp too?
+    #/usr/bin/docker run --rm -t --name ucp \
+    #    -v /var/run/docker.sock:/var/run/docker.sock \
+    #    docker/ucp uninstall --id=`cat {{ ucp_remote_dir }}/{{ ucp_instance_id_file }}` \
+    ;;
+
+*)
+    echo USAGE: $usage
+    exit 1
+    ;;
+esac

--- a/site.yml
+++ b/site.yml
@@ -50,7 +50,7 @@
   - { role: etcd, run_as: master }
   - { role: ceph-mon, mon_group_name: service-master }
   - { role: ceph-osd, mon_group_name: service-master, osd_group_name: service-master }
-  - { role: swarm, run_as: master }
+  - { role: scheduler_stack, run_as: master }
   - { role: contiv_network, run_as: master }
   - { role: contiv_storage, run_as: master }
 
@@ -64,7 +64,7 @@
   - { role: docker }
   - { role: etcd, run_as: worker }
   - { role: ceph-osd, mon_group_name: service-master, osd_group_name: service-worker }
-  - { role: swarm, run_as: worker }
+  - { role: scheduler_stack, run_as: worker }
   - { role: contiv_network, run_as: worker }
   - { role: contiv_storage, run_as: worker }
 


### PR DESCRIPTION
This PR brings in the mechanism to plug different scheduler stacks (on lines of discussion in #9) in our ansible and brings in support for docker UCP.

Changes:
- added a role `scheduler_stack` with alll supported scheduler as it's conditional dependencies
- `scheduler_provider` variable determines which scheduler stack to deploy. To being with we will support native-swarm (i.e. what exists today) and ucp-swam (i.e. the ucp stack)
- added tasks for installing ucp
- added tasks for cleaning up ucp

ping @jainvipin @erikh . PTAL when you get a chance
