### PR TITLE
Adding fwd_mode option to start netplugin

### DIFF
--- a/roles/contiv_network/defaults/main.yml
+++ b/roles/contiv_network/defaults/main.yml
@@ -6,3 +6,4 @@
 
 contiv_network_mode: "standalone" # Accepted values: standalone, aci
 netplugin_mode: "docker" # Accepted values: docker, kubernetes
+fwd_mode: "bridge" #Accepted values: bridge , routing

--- a/roles/contiv_network/templates/netplugin.j2
+++ b/roles/contiv_network/templates/netplugin.j2
@@ -1,1 +1,1 @@
-NETPLUGIN_ARGS='-plugin-mode {{netplugin_mode}} -vlan-if {{netplugin_if}} -vtep-ip {{node_addr}}'
+NETPLUGIN_ARGS='-plugin-mode {{netplugin_mode}} -vlan-if {{netplugin_if}} -vtep-ip {{node_addr}} -fwd-mode {{fwd_mode}}'


### PR DESCRIPTION
The change contains addition of fwd mode option to start netplugin in routing or bridge mode. 
