### PR TITLE
do not use sudo for local fetch ucp task

### DIFF
--- a/roles/ucp/tasks/main.yml
+++ b/roles/ucp/tasks/main.yml
@@ -29,6 +29,7 @@
 
 - name: create a local fetch directory if it doesn't exist
   local_action: file path={{ ucp_local_dir }} state=directory
+  sudo: false
   when: run_as == "master"
 
 - name: wait for ucp files to be created, which ensures the service has started


### PR DESCRIPTION
- ansible has issues while mixing up local_action and root access.
- Fix for #79 
- For this fix itself to work we need ansible 2.0.

references: https://github.com/ansible/ansible/issues/10906
