### PR TITLE
move serf from devtest host-group to the new cluster-node host-group

### DIFF
--- a/roles/serf/tasks/main.yml
+++ b/roles/serf/tasks/main.yml
@@ -6,8 +6,6 @@
     validate_certs: "{{ validate_certs }}"
     url: https://releases.hashicorp.com/serf/0.6.4/serf_0.6.4_linux_amd64.zip
     dest: /tmp/0.6.4_linux_amd64.zip
-  tags:
-    - prebake-for-dev
 
 - name: install serf
   unarchive:
@@ -15,20 +13,12 @@
     src: /tmp/0.6.4_linux_amd64.zip
     dest: /usr/bin
     creates: /usr/bin/serf
-  tags:
-    - prebake-for-dev
 
 - name: copy the serf start/stop script
   template: src=serf.j2 dest=/usr/bin/serf.sh mode=u=rwx,g=rx,o=rx
-  tags:
-    - prebake-for-dev
 
 - name: copy systemd units for serf
   copy: src=serf.service dest=/etc/systemd/system/serf.service
-  tags:
-    - prebake-for-dev
 
 - name: enable serf to be started on boot-up and start it as well
   service: name=serf state=started enabled=yes
-  tags:
-    - prebake-for-dev

--- a/site.yml
+++ b/site.yml
@@ -12,7 +12,6 @@
   environment: '{{ env }}'
   roles:
   - { role: base }
-  - { role: serf }
   - { role: dev }
   - { role: test }
 
@@ -28,6 +27,16 @@
   - { role: ceph-mon, mon_group_name: volplugin-test }
   - { role: ceph-osd, mon_group_name: volplugin-test, osd_group_name: volplugin-test }
   - { role: swarm, run_as: master }
+
+# cluster-node hosts corresponds to the hosts that shall be managed by cluster manager.
+# This host group shall provision a host with all required packages needed to make
+# the node ready to be managed by cluster-manager
+- hosts: cluster-node
+  sudo: true
+  environment: '{{ env }}'
+  roles:
+  - { role: base }
+  - { role: serf }
 
 # cluster-control hosts corresponds to the first machine in the cluster that is provisioned
 # to bootstrap the cluster by starting cluster manager and inventory database (collins)


### PR DESCRIPTION
serf requires a interface/netdevice on the host to start it's discovery protocol. We don't have that knowledge while provisioning a devtest host.

serf is required for auto-discovery of nodes, which is core to node management
in contiv cluster-manager work-flows. We introduce a new host-group viz. cluster-node
for provisioning a node with all base packages required to prepare the node
for management by cluster-manager. This host-group can be used to onboard a stock host
into the cluster-manager purview.

/cc @erikh 
