### PR TITLE
ansible: enable profile_tasks

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+callback_whitelist = profile_tasks


### PR DESCRIPTION
ansible 2.x includes the profile_tasks plugin. We can enable this using ansible.cfg. We don't need to include the plugin because ansible 2.x already ships it.

I've tested this with a tiny playbook.

Fixes #18 
