### PR TITLE
Misc fixes and enhancements

### DIFF
--- a/cleanup.yml
+++ b/cleanup.yml
@@ -6,11 +6,9 @@
 - hosts: all
   sudo: true
   tasks:
-    - include_vars: roles/{{ item }}/vars/main.yml
-      with_items:
-      - "etcd"
     - include_vars: roles/{{ item }}/defaults/main.yml
       with_items:
+      - "etcd"
       - "ucp"
     - include: roles/contiv_network/tasks/cleanup.yml
       ignore_errors: yes
@@ -36,6 +34,7 @@
     #    - contiv_storage
     #    - contiv_cluster
     #    - swarm
+    #    - ucp
     #    - docker
     #    - etcd
     #    - ucarp

--- a/roles/base/tasks/os_agnostic_tasks.yml
+++ b/roles/base/tasks/os_agnostic_tasks.yml
@@ -2,7 +2,13 @@
   get_url:
     validate_certs: "{{ validate_certs }}"
     url: https://releases.hashicorp.com/consul/0.5.2/consul_0.5.2_linux_amd64.zip
-    dest: /tmp/consul.zip
+    dest: /tmp/consul_0.5.2_linux_amd64.zip
+    force: no
+  register: download_result
 
 - name: install consul
-  shell: "chdir=/tmp creates=/usr/bin/consul unzip /tmp/consul.zip && mv /tmp/consul /usr/bin"
+  unarchive:
+    copy: no
+    src: /tmp/consul_0.5.2_linux_amd64.zip
+    dest: /usr/bin
+  when: download_result | changed

--- a/roles/contiv_network/defaults/main.yml
+++ b/roles/contiv_network/defaults/main.yml
@@ -12,3 +12,8 @@ contiv_network_version: "v0.1-02-06-2016.14-42-05.UTC"
 contiv_network_tar_file: "netplugin-{{ contiv_network_version }}.tar.bz2"
 contiv_network_src_file: "https://github.com/contiv/netplugin/releases/download/{{ contiv_network_version }}/{{ contiv_network_tar_file }}"
 contiv_network_dest_file: "/tmp/{{ contiv_network_tar_file }}"
+
+contivctl_version: "v0.0.0-01-31-2016.17-56-53.UTC"
+contivctl_tar_file: "contivctl-{{ contivctl_version }}.tar.bz2"
+contivctl_src_file: "https://github.com/contiv/contivctl/releases/download/{{ contivctl_version }}/{{ contivctl_tar_file }}"
+contivctl_dest_file: "/tmp/{{ contivctl_tar_file }}"

--- a/roles/contiv_network/tasks/main.yml
+++ b/roles/contiv_network/tasks/main.yml
@@ -74,15 +74,16 @@
 - name: download contivctl
   get_url:
     validate_certs: "{{ validate_certs }}"
-    url: https://github.com/contiv/contivctl/releases/download/v0.0.0-01-31-2016.17-56-53.UTC/contivctl-v0.0.0-01-31-2016.17-56-53.UTC.tar.bz2
-    dest: /tmp/contivctl-v0.0.0-01-31-2016.17-56-53.UTC.tar.bz2
+    url: "{{ contivctl_src_file }}"
+    dest: "{{ contivctl_dest_file }}"
     force: no
+  register: download_result
 
 - name: install contivctl
-  shell: tar vxjf /tmp/contivctl-v0.0.0-01-31-2016.17-56-53.UTC.tar.bz2
+  shell: tar vxjf {{ contivctl_dest_file }}
   args:
     chdir: /usr/bin/
-    creates: contivctl
+  when: download_result | changed
 
 - include: aci_tasks.yml
   when: (run_as == "master") and (contiv_network_mode == "aci")

--- a/roles/serf/tasks/main.yml
+++ b/roles/serf/tasks/main.yml
@@ -5,14 +5,16 @@
   get_url:
     validate_certs: "{{ validate_certs }}"
     url: https://releases.hashicorp.com/serf/0.6.4/serf_0.6.4_linux_amd64.zip
-    dest: /tmp/0.6.4_linux_amd64.zip
+    dest: /tmp/serf_0.6.4_linux_amd64.zip
+    force: no
+  register: download_result
 
 - name: install serf
   unarchive:
     copy: no
-    src: /tmp/0.6.4_linux_amd64.zip
+    src: /tmp/serf_0.6.4_linux_amd64.zip
     dest: /usr/bin
-    creates: /usr/bin/serf
+  when: download_result | changed
 
 - name: copy the serf start/stop script
   template: src=serf.j2 dest=/usr/bin/serf.sh mode=u=rwx,g=rx,o=rx


### PR DESCRIPTION
- Update cleanup playbook to use etcd variables from default dir. fixes #90 
- fix/cleanup various download/install tasks to use the result of `get_url` task. fixes: #89 

/cc @erikh @vvb 
