### PR TITLE
ansible/roles/swarm: Use hostname, not ip address, to determine the manager

### DIFF
--- a/roles/swarm/defaults/main.yml
+++ b/roles/swarm/defaults/main.yml
@@ -2,4 +2,4 @@
 # role variable for the swarm service
 #
 swarm_api_port: 2375
-swarm_bootstrap_node_addr: ""
+swarm_bootstrap_node_name: ""

--- a/roles/swarm/templates/swarm.j2
+++ b/roles/swarm/templates/swarm.j2
@@ -9,7 +9,7 @@ fi
 case $1 in
 start)
     echo starting swarm on {{ node_name }}[{{ node_addr }}]
-    {% if swarm_bootstrap_node_addr == node_addr -%}
+    {% if swarm_bootstrap_node_name == node_name -%}
     /usr/bin/swarm manage -H tcp://{{ node_addr }}:{{ swarm_api_port }} etcd://{{ node_addr }}:{{ etcd_client_port1 }} &
     {% endif %}
 


### PR DESCRIPTION
This enables volplugin to use swarm in a way that doesn't depend on knowing the IP first.
