### PR TITLE
avoid re-install of ansible, upgrade ucp version to 1.0.0

### DIFF
--- a/roles/base/tasks/redhat_tasks.yml
+++ b/roles/base/tasks/redhat_tasks.yml
@@ -39,7 +39,15 @@
   shell: rm -rf /usr/lib64/python2.7/site-packages/pycrypto-*.egg-info
   when: '"Error unpacking rpm package python2-crypto-" in python_crypto_result.msg'
 
+- name: download ansible binary (redhat)
+  get_url:
+    url: http://ftp.gnome.org/mirror/fedora/epel/testing/7/x86_64/a/ansible-2.0.0.2-1.el7.noarch.rpm
+    dest: /tmp/ansible-2.0.0.2-1.el7.noarch.rpm
+    force: no
+  register: download_result
+
 - name: install ansible (redhat)
   yum:
-    name: http://ftp.gnome.org/mirror/fedora/epel/testing/7/x86_64/a/ansible-2.0.0.2-1.el7.noarch.rpm
+    name: /tmp/ansible-2.0.0.2-1.el7.noarch.rpm
     state: present
+  when: download_result | changed

--- a/roles/base/tasks/redhat_tasks.yml
+++ b/roles/base/tasks/redhat_tasks.yml
@@ -39,7 +39,7 @@
   shell: rm -rf /usr/lib64/python2.7/site-packages/pycrypto-*.egg-info
   when: '"Error unpacking rpm package python2-crypto-" in python_crypto_result.msg'
 
-- name: download ansible binary (redhat)
+- name: download ansible rpm (redhat)
   get_url:
     url: http://ftp.gnome.org/mirror/fedora/epel/testing/7/x86_64/a/ansible-2.0.0.2-1.el7.noarch.rpm
     dest: /tmp/ansible-2.0.0.2-1.el7.noarch.rpm

--- a/roles/ucp/defaults/main.yml
+++ b/roles/ucp/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # Role defaults for ucp
 
-ucp_version: "0.8.0"
+ucp_version: "1.0.0"
 ucp_local_dir: "fetch/ucp"
 ucp_remote_dir: "/tmp"
 ucp_instance_id_file: "ucp-instance-id"


### PR DESCRIPTION
we try to re-install ansbile when the task runs as a part of another host-group. This commits will prevent it.
older versions of UCP are not available anymore - hence moving to 1.0.0
