### PR TITLE
Multiple fixes

### DIFF
--- a/roles/contiv_network/defaults/main.yml
+++ b/roles/contiv_network/defaults/main.yml
@@ -8,7 +8,7 @@ contiv_network_mode: "standalone" # Accepted values: standalone, aci
 netplugin_mode: "docker" # Accepted values: docker, kubernetes
 fwd_mode: "bridge" #Accepted values: bridge , routing
 
-contiv_network_version: "v0.1-02-25-2016.09-29-08.UTC"
+contiv_network_version: "v0.1-02-27-2016.09-27-46.UTC"
 contiv_network_tar_file: "netplugin-{{ contiv_network_version }}.tar.bz2"
 contiv_network_src_file: "https://github.com/contiv/netplugin/releases/download/{{ contiv_network_version }}/{{ contiv_network_tar_file }}"
 contiv_network_dest_file: "/tmp/{{ contiv_network_tar_file }}"

--- a/roles/swarm/defaults/main.yml
+++ b/roles/swarm/defaults/main.yml
@@ -2,4 +2,4 @@
 # role variable for the swarm service
 #
 swarm_api_port: 2375
-swarm_bootstrap_node_name: ""
+swarm_version: "1.1.2"

--- a/roles/swarm/files/swarm.service
+++ b/roles/swarm/files/swarm.service
@@ -4,4 +4,5 @@ After=auditd.service systemd-user-sessions.service time-sync.target etcd.service
 
 [Service]
 ExecStart=/usr/bin/swarm.sh start
+ExecStop=/usr/bin/swarm.sh stop
 KillMode=control-group

--- a/roles/swarm/tasks/main.yml
+++ b/roles/swarm/tasks/main.yml
@@ -1,13 +1,8 @@
 ---
 # This role contains tasks for configuring and starting swarm service
 
-- name: download and install swarm
-  get_url:
-    validate_certs: "{{ validate_certs }}"
-    url: https://cisco.box.com/shared/static/0txiq5h7282hraujk09eleoevptd5jpl
-    dest: /usr/bin/swarm
-    mode: u=rwx,g=rx,o=rx
-    force: no
+- name: download swarm container image
+  shell: docker pull swarm:{{ swarm_version }}
   tags:
     - prebake-for-dev
 
@@ -18,4 +13,4 @@
   copy: src=swarm.service dest=/etc/systemd/system/swarm.service
 
 - name: start swarm
-  shell: systemctl daemon-reload && systemctl start swarm
+  service: name=swarm state=started

--- a/roles/swarm/templates/swarm.j2
+++ b/roles/swarm/templates/swarm.j2
@@ -8,12 +8,26 @@ fi
 
 case $1 in
 start)
-    echo starting swarm as on {{ node_name }}[{{ node_addr }}]
-    {% if swarm_bootstrap_node_name == node_name %}
-        /usr/bin/swarm manage -H tcp://{{ node_addr }}:{{ swarm_api_port }} etcd://{{ node_addr }}:{{ etcd_client_port1 }} &
+    echo starting swarm as {{ run_as }} on {{ node_name }}[{{ node_addr }}]
+    {% if run_as == "master" -%}
+    /usr/bin/docker run -t -d -p {{ swarm_api_port }}:{{ swarm_api_port }} --name=swarm-manager \
+        swarm:{{ swarm_version }} manage \
+        -H :{{ swarm_api_port }} \
+        --replication --advertise={{ node_addr }}:{{ swarm_api_port }} \
+        etcd://{{ node_addr }}:{{ etcd_client_port1 }}
     {% endif %}
+    /usr/bin/docker run -t --name=swarm-agent \
+        swarm:{{ swarm_version }} join \
+        --advertise={{ node_addr }}:{{ docker_api_port }} \
+        etcd://{{ node_addr }}:{{ etcd_client_port1 }}
+    ;;
 
-    /usr/bin/swarm join --advertise={{ node_addr }}:{{ docker_api_port }} etcd://{{ node_addr }}:{{ etcd_client_port1 }}
+stop)
+    # skipping `set -e` as we shouldn't stop on error
+    /usr/bin/docker stop swarm-manager
+    /usr/bin/docker rm swarm-manager
+    /usr/bin/docker stop swarm-agent
+    /usr/bin/docker rm swarm-agent
     ;;
 
 *)

--- a/roles/ucp/defaults/main.yml
+++ b/roles/ucp/defaults/main.yml
@@ -7,7 +7,7 @@ ucp_remote_dir: "/tmp"
 ucp_instance_id_file: "ucp-instance-id"
 ucp_fingerprint_file: "ucp-fingerprint"
 ucp_fifo_file: "ucp-fifo"
-ucp_bootstrap_node_addr: ""
+ucp_bootstrap_node_name: ""
 
 ucp_admin_user: "admin"
 ucp_admin_password: "orca"

--- a/roles/ucp/tasks/main.yml
+++ b/roles/ucp/tasks/main.yml
@@ -16,7 +16,7 @@
   with_items:
     - "{{ ucp_fingerprint_file }}"
     - "{{ ucp_instance_id_file }}"
-  when: node_addr != ucp_bootstrap_node_addr
+  when: node_name != ucp_bootstrap_node_name
 
 - name: copy the ucp start/stop script
   template: src=ucp.j2 dest=/usr/bin/ucp.sh mode=u=rwx,g=rx,o=rx
@@ -39,7 +39,7 @@
   with_items:
     - "{{ ucp_fingerprint_file }}"
     - "{{ ucp_instance_id_file }}"
-  when: node_addr == ucp_bootstrap_node_addr
+  when: node_name == ucp_bootstrap_node_name
 
 - name: fetch the ucp files from master nodes
   fetch:
@@ -50,4 +50,4 @@
   with_items:
     - "{{ ucp_fingerprint_file }}"
     - "{{ ucp_instance_id_file }}"
-  when: node_addr == ucp_bootstrap_node_addr
+  when: node_name == ucp_bootstrap_node_name

--- a/roles/ucp/templates/ucp.j2
+++ b/roles/ucp/templates/ucp.j2
@@ -12,7 +12,7 @@ start)
 
     echo starting ucp on {{ node_name }}[{{ node_addr }}]
 
-    {% if ucp_bootstrap_node_addr == node_addr -%}
+    {% if ucp_bootstrap_node_name == node_name -%}
     out=$(/usr/bin/docker run --rm -t --name ucp \
         -v /var/run/docker.sock:/var/run/docker.sock \
         docker/ucp install --host-address={{ node_addr }} \


### PR DESCRIPTION
- use `--replication` flag for swarm. Also note that unlike ucp, we no longer need bootstartp node logic for swarm. Fixes #88 
- move to using swarm container image
- replace `ucp_bootstrap_node_addr` with `ucp_bootstrap_node_name`. Fixes #98 
- also bumped up netplugin version to pull a netctl fix https://github.com/contiv/netplugin/pull/294

/cc @erikh @vvb 
