### PR TITLE
mon-osd separation fixes. making netplugin optional for service_worker

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -25,3 +25,10 @@ validate_certs: "yes"
 # env:
 # service_vip:
 # control_interface:
+
+# should mons also run osds
+mon_osd_colocation_allowed: "true"
+
+# OSDs could be run without netplugin on them
+# osd_contiv_network_include controls this behaviour
+osd_contiv_network_include: "true"

--- a/group_vars/all
+++ b/group_vars/all
@@ -26,4 +26,4 @@ validate_certs: "yes"
 # service_vip:
 # control_interface:
 
-host_capability: "compute, storage, network"
+host_capability: "can-run-user-containers, storage"

--- a/group_vars/all
+++ b/group_vars/all
@@ -26,9 +26,4 @@ validate_certs: "yes"
 # service_vip:
 # control_interface:
 
-# should mons also run osds
-mon_osd_colocation_allowed: "true"
-
-# OSDs could be run without netplugin on them
-# osd_contiv_network_include controls this behaviour
-osd_contiv_network_include: "true"
+host_capability: "compute, storage, network"

--- a/roles/ceph-common/handlers/main.yml
+++ b/roles/ceph-common/handlers/main.yml
@@ -3,6 +3,18 @@
   apt:
     update-cache: yes
 
+- name: check for a ceph socket
+  shell: "stat /var/run/ceph/*.asok > /dev/null 2>&1"
+  changed_when: false
+  failed_when: false
+  register: socket
+
+- name: check for a rados gateway socket
+  shell: "stat {{ rbd_client_admin_socket_path }}*.asok > /dev/null 2>&1"
+  changed_when: false
+  failed_when: false
+  register: socketrgw
+
 - name: restart ceph mons
   command: service ceph restart mon
   when:

--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -37,18 +37,6 @@
     radosgw_frontend == 'apache' and
     rgw_group_name in group_names
 
-- name: check for a ceph socket
-  shell: "stat /var/run/ceph/*.asok > /dev/null 2>&1"
-  changed_when: false
-  failed_when: false
-  register: socket
-
-- name: check for a rados gateway socket
-  shell: "stat {{ rbd_client_admin_socket_path }}*.asok > /dev/null 2>&1"
-  changed_when: false
-  failed_when: false
-  register: socketrgw
-
 - name: create a local fetch directory if it doesn't exist
   local_action: file path={{ fetch_directory }} state=directory
   changed_when: false
@@ -86,6 +74,8 @@
     group: root
     mode: 0644
   notify:
+    - check for a ceph socket
+    - check for a rados gateway socket
     - restart ceph mons
     - restart ceph mons on ubuntu
     - restart ceph mons with systemd

--- a/site.yml
+++ b/site.yml
@@ -59,11 +59,11 @@
   - { role: ucarp }
   - { role: docker }
   - { role: etcd, run_as: master }
-  - { role: ceph-mon, mon_group_name: service-master }
-  - { role: ceph-osd, mon_group_name: service-master, osd_group_name: service-master, when: host_capability|match('.*storage.*') }
-  - { role: scheduler_stack, run_as: master }
-  - { role: contiv_network, run_as: master, when: host_capability|match('.*network.*') }
-  - { role: contiv_storage, run_as: master }
+#  - { role: ceph-mon, mon_group_name: service-master, when: host_capability|match('.*can-run-user-containers.*') }
+#  - { role: ceph-osd, mon_group_name: service-master, osd_group_name: service-master, when: host_capability|match('.*storage.*') }
+  - { role: scheduler_stack, run_as: master, when: host_capability|match('.*can-run-user-containers.*') }
+  - { role: contiv_network, run_as: master, when: host_capability|match('.*can-run-user-containers.*') }
+#  - { role: contiv_storage, run_as: master }
 
 # service-worker hosts correspond to cluster machines that run the worker/driver
 # logic of the infra services.
@@ -74,10 +74,10 @@
   - { role: base }
   - { role: docker }
   - { role: etcd, run_as: worker }
-  - { role: ceph-osd, mon_group_name: service-master, osd_group_name: service-worker, when: host_capability|match('.*storage.*') }
-  - { role: scheduler_stack, run_as: worker }
-  - { role: contiv_network, run_as: worker, when: host_capability|match('.*network.*') }
-  - { role: contiv_storage, run_as: worker }
+#  - { role: ceph-osd, mon_group_name: service-master, osd_group_name: service-worker, when: host_capability|match('.*storage.*') }
+  - { role: scheduler_stack, run_as: worker, when: host_capability|match('.*can-run-user-containers.*') }
+  - { role: contiv_network, run_as: worker, when: host_capability|match('.*can-run-user-containers.*') }
+#  - { role: contiv_storage, run_as: worker }
 
 # netplugin-node hosts set up netmast/netplugin in a cluster
 - hosts: netplugin-node

--- a/site.yml
+++ b/site.yml
@@ -59,11 +59,11 @@
   - { role: ucarp }
   - { role: docker }
   - { role: etcd, run_as: master }
-  #- { role: ceph-mon, mon_group_name: service-master }
-  #- { role: ceph-osd, mon_group_name: service-master, osd_group_name: service-master }
+  - { role: ceph-mon, mon_group_name: service-master }
+  - { role: ceph-osd, mon_group_name: service-master, osd_group_name: service-master, when: host_capability|match('.*storage.*') }
   - { role: scheduler_stack, run_as: master }
-  - { role: contiv_network, run_as: master }
-  #- { role: contiv_storage, run_as: master }
+  - { role: contiv_network, run_as: master, when: host_capability|match('.*network.*') }
+  - { role: contiv_storage, run_as: master }
 
 # service-worker hosts correspond to cluster machines that run the worker/driver
 # logic of the infra services.
@@ -74,10 +74,10 @@
   - { role: base }
   - { role: docker }
   - { role: etcd, run_as: worker }
-  #- { role: ceph-osd, mon_group_name: service-master, osd_group_name: service-worker }
+  - { role: ceph-osd, mon_group_name: service-master, osd_group_name: service-worker, when: host_capability|match('.*storage.*') }
   - { role: scheduler_stack, run_as: worker }
-  - { role: contiv_network, run_as: worker }
-  #- { role: contiv_storage, run_as: worker }
+  - { role: contiv_network, run_as: worker, when: host_capability|match('.*network.*') }
+  - { role: contiv_storage, run_as: worker }
 
 # netplugin-node hosts set up netmast/netplugin in a cluster
 - hosts: netplugin-node


### PR DESCRIPTION
1. optionally running only mons on the service-master cluster. the osds are run only on service-worker in this mode. The ceph-playbook changes in this PR, are to deal with ansible's behaviour of how it deals with conditionals at the role level. It runs every task in the role applying the conditional to it. In this specific case the "check" tasks were doing a `stat` and registering the output to a variable `socket`. When the task is skipped `socket` is not what it needs to be. There are handlers that kick-in at the end of service-master workflow that depend on `socket` to be correct. so, the correct solution is to do the stat when the handlers are fired, so that the true state is reflected.
2. Making contiv_network optional for the service-worker hostgroup.
3. Necessary defaults which do not change the current behaviour. 
