### PR TITLE
bump up contivctl version

### DIFF
--- a/roles/contiv_network/defaults/main.yml
+++ b/roles/contiv_network/defaults/main.yml
@@ -13,7 +13,7 @@ contiv_network_tar_file: "netplugin-{{ contiv_network_version }}.tar.bz2"
 contiv_network_src_file: "https://github.com/contiv/netplugin/releases/download/{{ contiv_network_version }}/{{ contiv_network_tar_file }}"
 contiv_network_dest_file: "/tmp/{{ contiv_network_tar_file }}"
 
-contivctl_version: "v0.0.0-02-18-2016.22-10-53.UTC"
+contivctl_version: "v0.0.0-03-01-2016.10-40-56.UTC"
 contivctl_tar_file: "contivctl-{{ contivctl_version }}.tar.bz2"
 contivctl_src_file: "https://github.com/contiv/contivctl/releases/download/{{ contivctl_version }}/{{ contivctl_tar_file }}"
 contivctl_dest_file: "/tmp/{{ contivctl_tar_file }}"


### PR DESCRIPTION
this is to pull in netctl fix (https://github.com/contiv/netplugin/pull/294) required for demo installer
