### PR TITLE
temporarily comment out ceph tasks from service-master and worker host groups

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -59,11 +59,11 @@
   - { role: ucarp }
   - { role: docker }
   - { role: etcd, run_as: master }
-  - { role: ceph-mon, mon_group_name: service-master }
-  - { role: ceph-osd, mon_group_name: service-master, osd_group_name: service-master }
+  #- { role: ceph-mon, mon_group_name: service-master }
+  #- { role: ceph-osd, mon_group_name: service-master, osd_group_name: service-master }
   - { role: scheduler_stack, run_as: master }
   - { role: contiv_network, run_as: master }
-  - { role: contiv_storage, run_as: master }
+  #- { role: contiv_storage, run_as: master }
 
 # service-worker hosts correspond to cluster machines that run the worker/driver
 # logic of the infra services.
@@ -74,10 +74,10 @@
   - { role: base }
   - { role: docker }
   - { role: etcd, run_as: worker }
-  - { role: ceph-osd, mon_group_name: service-master, osd_group_name: service-worker }
+  #- { role: ceph-osd, mon_group_name: service-master, osd_group_name: service-worker }
   - { role: scheduler_stack, run_as: worker }
   - { role: contiv_network, run_as: worker }
-  - { role: contiv_storage, run_as: worker }
+  #- { role: contiv_storage, run_as: worker }
 
 # netplugin-node hosts set up netmast/netplugin in a cluster
 - hosts: netplugin-node


### PR DESCRIPTION
ceph play doesn't work well with clustermgr workflow due to ansible/issues/19. Commenting these plays so that cluster/master can continue to work until we have fixed the ansible.

/cc @vvb 
