### PR TITLE
remove the blanket yum upgrade task

### DIFF
--- a/roles/base/tasks/redhat_tasks.yml
+++ b/roles/base/tasks/redhat_tasks.yml
@@ -1,17 +1,14 @@
-- name: upgrade system (redhat)
-  yum:
-    update_cache: true
-    name: '*'
-    state: latest
-
 # install epel-release first to ensure the extra packages can be installed later
 - name: install epel release package (redhat)
   yum:
     name: epel-release
+    state: latest
 
-- name: install base packages (redhat)
+- name: install/upgrade base packages (redhat)
   yum:
     name: "{{ item }}"
+    update_cache: true
+    state: latest
   with_items:
     - ntp
     - unzip
@@ -26,6 +23,7 @@
     - lshw
     - python-requests # XXX required by ceph repo, but it has a bad package on it
     - bash-completion
+    - kernel #keep kernel up to date
 
 - name: install and start ntp
   shell: systemctl enable ntpd


### PR DESCRIPTION
a call to yum module with package name as \* causes yum to try and upgrade all the packages. This causes an unnecessary upgrade of certain packages like `docker-engine`, for which we want to control the version ourselves. It is desirable to use the appropriate state=latest or a specific version info
which each yum module call than in a single blanket task.

/cc @erikh @vvb 
