### PR TITLE
Vagrantfile: add paravirt KVM & network tweaks

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -43,6 +43,9 @@ Vagrant.configure(2) do |config|
         node.vm.provider "virtualbox" do |vb|
             vb.customize ['modifyvm', :id, '--memory', "4096"]
             vb.customize ["modifyvm", :id, "--cpus", "2"]
+            vb.customize ['modifyvm', :id, '--paravirtprovider', 'kvm']
+            vb.customize ['modifyvm', :id, '--natdnshostresolver1', 'on']
+            vb.customize ['modifyvm', :id, '--natdnsproxy1', 'on']
         end
 
         if ansible_groups["devtest"] == nil then


### PR DESCRIPTION
This PR makes the same change which has been made to other Vagrantfiles from the other repositories to use the KVM paravirtprovider. The PR also makes some small recommended tweaks to speed up the network in some cases.
