### PR TITLE
fix setup and cleanup logic for netmaster hosts alias

### DIFF
--- a/roles/contiv_network/tasks/cleanup.yml
+++ b/roles/contiv_network/tasks/cleanup.yml
@@ -7,6 +7,13 @@
 - name: stop netplugin
   service: name=netplugin state=stopped
 
+- name: cleanup netmaster host alias
+  lineinfile:
+    dest: /etc/hosts
+    regexp: " netmaster$"
+    state: absent
+  become: true
+
 - name: cleanup iptables for contiv network control plane
   shell: iptables -D INPUT -p tcp --dport {{ item }} -j ACCEPT -m comment --comment "{{ netplugin_rule_comment }} ({{ item }})"
   become: true

--- a/roles/contiv_network/tasks/main.yml
+++ b/roles/contiv_network/tasks/main.yml
@@ -67,7 +67,12 @@
   shell: systemctl daemon-reload && systemctl start netplugin
 
 - name: setup netmaster host alias
-  shell: echo "{{ service_vip }} netmaster" >> /etc/hosts
+  lineinfile:
+    dest: /etc/hosts
+    line: "{{ service_vip }} netmaster"
+    regexp: " netmaster$"
+    state: present
+  become: true
 
 - name: copy environment file for netmaster
   copy: src=netmaster dest=/etc/default/netmaster


### PR DESCRIPTION
- during setup, delete any netmaster host entry before adding a new one
- during cleanup, delete any netmaster host entry existing if any

fixes: #133 

/cc @DivyaVavili 
