### PR TITLE
Etcd related fixes

### DIFF
--- a/roles/base/tasks/os_agnostic_tasks.yml
+++ b/roles/base/tasks/os_agnostic_tasks.yml
@@ -3,12 +3,9 @@
     validate_certs: "{{ validate_certs }}"
     url: https://releases.hashicorp.com/consul/0.5.2/consul_0.5.2_linux_amd64.zip
     dest: /tmp/consul_0.5.2_linux_amd64.zip
-    force: no
-  register: download_result
 
 - name: install consul
   unarchive:
     copy: no
     src: /tmp/consul_0.5.2_linux_amd64.zip
     dest: /usr/bin
-  when: download_result | changed

--- a/roles/contiv_cluster/tasks/main.yml
+++ b/roles/contiv_cluster/tasks/main.yml
@@ -32,14 +32,11 @@
     validate_certs: "{{ validate_certs }}"
     url: "{{ contiv_cluster_src_file }}" 
     dest: "{{ contiv_cluster_dest_file }}"
-    force: no
-  register: download_result
 
 - name: install clusterm
   shell: tar vxjf {{ contiv_cluster_dest_file }} 
   args:
     chdir: /usr/bin/
-  when: download_result | changed 
 
 - name: create conf dir for clusterm
   file:

--- a/roles/contiv_storage/tasks/main.yml
+++ b/roles/contiv_storage/tasks/main.yml
@@ -6,13 +6,11 @@
     validate_certs: "{{ validate_certs }}"
     url: "{{ contiv_storage_src_file }}"
     dest: "{{ contiv_storage_dest_file }}"
-  register: download_result
 
 - name: install storage service
   shell: tar vxjf {{ contiv_storage_dest_file }}
   args:
     chdir: /usr/bin/
-  when: download_result | changed 
 
 - name: copy environment file for volmaster
   copy: src=volmaster dest=/etc/default/volmaster

--- a/roles/dev/tasks/os_agnostic_tasks.yml
+++ b/roles/dev/tasks/os_agnostic_tasks.yml
@@ -3,14 +3,11 @@
     validate_certs: "{{ validate_certs }}"
     url: https://storage.googleapis.com/golang/go1.6.linux-amd64.tar.gz
     dest: /tmp/go1.6.linux-amd64.tar.gz
-    force: no
-  register: download_result
 
 - name: install Golang
   shell: rm -rf go/ && tar xfvz /tmp/go1.6.linux-amd64.tar.gz
   args:
     chdir: /usr/local/
-  when: download_result | changed
 
 - name: setup golang environment
   copy:

--- a/roles/etcd/defaults/main.yml
+++ b/roles/etcd/defaults/main.yml
@@ -10,6 +10,8 @@ etcd_init_cluster: true
 etcd_tmp_filename: "/tmp/etcd.existing"
 etcd_rule_comment: "etcd traffic"
 etcd_version: "v2.3.1"
+etcd_heartbeat_interval: 1000
+etcd_election_timeout: 10000
 
 # following variables are used in one or more roles, but have no good default value to pick from.
 # Leaving them as commented so that playbooks can fail early with variable not defined error.

--- a/roles/etcd/defaults/main.yml
+++ b/roles/etcd/defaults/main.yml
@@ -9,6 +9,7 @@ etcd_peers_group: "service-master"
 etcd_init_cluster: true
 etcd_tmp_filename: "/tmp/etcd.existing"
 etcd_rule_comment: "etcd traffic"
+etcd_version: "v2.3.1"
 
 # following variables are used in one or more roles, but have no good default value to pick from.
 # Leaving them as commented so that playbooks can fail early with variable not defined error.

--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -6,12 +6,13 @@
     validate_certs: "{{ validate_certs }}"
     url: https://github.com/coreos/etcd/releases/download/{{ etcd_version }}/etcd-{{ etcd_version }}-linux-amd64.tar.gz
     dest: /tmp/etcd-{{ etcd_version }}-linux-amd64.tar.gz
-    force: no
   tags:
     - prebake-for-dev
 
 - name: install etcd
-  shell: creates=/usr/bin/etcd tar vxzf /tmp/etcd-{{ etcd_version }}-linux-amd64.tar.gz && mv etcd-{{ etcd_version }}-linux-amd64/etcd* /usr/bin
+  shell: >
+      tar vxzf /tmp/etcd-{{ etcd_version }}-linux-amd64.tar.gz && \
+      mv etcd-{{ etcd_version }}-linux-amd64/etcd* /usr/bin
   tags:
     - prebake-for-dev
 

--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -1,17 +1,17 @@
 ---
 # This role contains tasks for configuring and starting etcd service
 
-- name: download etcd v2.1.1
+- name: download etcd {{ etcd_version }}
   get_url:
     validate_certs: "{{ validate_certs }}"
-    url: https://github.com/coreos/etcd/releases/download/v2.1.1/etcd-v2.1.1-linux-amd64.tar.gz
-    dest: /tmp/etcd-v2.1.1-linux-amd64.tar.gz
+    url: https://github.com/coreos/etcd/releases/download/{{ etcd_version }}/etcd-{{ etcd_version }}-linux-amd64.tar.gz
+    dest: /tmp/etcd-{{ etcd_version }}-linux-amd64.tar.gz
     force: no
   tags:
     - prebake-for-dev
 
 - name: install etcd
-  shell: creates=/usr/bin/etcd tar vxzf /tmp/etcd-v2.1.1-linux-amd64.tar.gz && mv etcd-v2.1.1-linux-amd64/etcd* /usr/bin
+  shell: creates=/usr/bin/etcd tar vxzf /tmp/etcd-{{ etcd_version }}-linux-amd64.tar.gz && mv etcd-{{ etcd_version }}-linux-amd64/etcd* /usr/bin
   tags:
     - prebake-for-dev
 

--- a/roles/etcd/templates/etcd.j2
+++ b/roles/etcd/templates/etcd.j2
@@ -13,6 +13,8 @@ export ETCD_LISTEN_CLIENT_URLS=http://0.0.0.0:{{ etcd_client_port1 }},http://0.0
 export ETCD_ADVERTISE_CLIENT_URLS=http://{{ node_addr }}:{{ etcd_client_port1 }},http://{{ node_addr }}:{{ etcd_client_port2 }}
 export ETCD_INITIAL_ADVERTISE_PEER_URLS=http://{{ node_addr }}:{{ etcd_peer_port1 }},http://{{ node_addr }}:{{ etcd_peer_port2 }}
 export ETCD_LISTEN_PEER_URLS=http://{{ node_addr }}:{{ etcd_peer_port1 }}
+export ETCD_HEARTBEAT_INTERVAL={{ etcd_heartbeat_interval }}
+export ETCD_ELECTION_TIMEOUT={{ etcd_election_timeout }}
 
 case $1 in
 start)

--- a/roles/etcd/templates/etcd.j2
+++ b/roles/etcd/templates/etcd.j2
@@ -6,6 +6,7 @@ if [ $# -ne 1 ]; then
     exit 1
 fi
 
+set -x
 export ETCD_NAME={{ node_name }}
 export ETCD_DATA_DIR=/var/lib/etcd
 export ETCD_INITIAL_CLUSTER_TOKEN=contiv-cluster

--- a/roles/serf/tasks/main.yml
+++ b/roles/serf/tasks/main.yml
@@ -23,15 +23,12 @@
     validate_certs: "{{ validate_certs }}"
     url: https://releases.hashicorp.com/serf/0.6.4/serf_0.6.4_linux_amd64.zip
     dest: /tmp/serf_0.6.4_linux_amd64.zip
-    force: no
-  register: download_result
 
 - name: install serf
   unarchive:
     copy: no
     src: /tmp/serf_0.6.4_linux_amd64.zip
     dest: /usr/bin
-  when: download_result | changed
 
 - name: copy the serf start/stop script
   template: src=serf.j2 dest=/usr/bin/serf.sh mode=u=rwx,g=rx,o=rx


### PR DESCRIPTION
- made etcd version configurable through variable. I am starting with default version as 2.3.1
- made the etcd timeout values configurable and set them to some conservative values
- also fixed a issue with use of `download_result` based installation logic. Fixes #154 

/cc @erikh @shaleman  @unclejack . I am assuming volplugin ad netplugin are going to be fine with this upgrade to newer etcd version.
