### PR TITLE
Update ovs_cleanup.yml

### DIFF
--- a/roles/contiv_network/tasks/ovs_cleanup.yml
+++ b/roles/contiv_network/tasks/ovs_cleanup.yml
@@ -26,7 +26,7 @@
 - debug: var=ports
 
 - name: cleanup iptables for vxlan vtep port
-  shell: iptables -D INPUT -p tcp --dport {{ item }} -j ACCEPT -m comment --comment "{{ netplugin_rule_comment }} ({{ item }})"
+  shell: iptables -D INPUT -p udp --dport {{ item }} -j ACCEPT -m comment --comment "{{ netplugin_rule_comment }} ({{ item }})"
   become: true
   with_items:
     - "{{ vxlan_port }}"


### PR DESCRIPTION
Changing current IPtables rule for VXLAN port. Changing protocol from tcp to udp. Tested on centos 7.
VXLAN uses udp protocol so need to change here .
