### PR TITLE
Adding a required package libselinux-python

### DIFF
--- a/roles/base/tasks/redhat_tasks.yml
+++ b/roles/base/tasks/redhat_tasks.yml
@@ -18,6 +18,7 @@
     - python-requests # XXX required by ceph repo, but it has a bad package on it
     - bash-completion
     - kernel #keep kernel up to date
+    - libselinux-python
 
 - name: install and start ntp
   service: name=ntpd state=started enabled=yes

--- a/roles/base/tasks/ubuntu_tasks.yml
+++ b/roles/base/tasks/ubuntu_tasks.yml
@@ -15,3 +15,4 @@
     - python-software-properties
     - librbd-dev
     - bash-completion
+    - python-selinux


### PR DESCRIPTION
Signed-off-by: Vikrant Balyan vijayvikrant84@gmail.com

Ansible workflow should work on a stock minimal centos image and libselinux-python is a required dependency that is missing in the current workflow.
