### PR TITLE
remove state --debug flag from contiv_storage

### DIFF
--- a/roles/base/files/volplugin.service
+++ b/roles/base/files/volplugin.service
@@ -1,7 +1,0 @@
-[Unit]
-Description=Volume Plugin
-After=auditd.service systemd-user-sessions.service time-sync.target
-
-[Service]
-ExecStart=/opt/golang/bin/volplugin --debug tenant1
-KillMode=process

--- a/roles/contiv_storage/files/volmaster
+++ b/roles/contiv_storage/files/volmaster
@@ -1,1 +1,1 @@
-VOLMASTER_ARGS="--debug"
+VOLMASTER_ARGS=""

--- a/roles/contiv_storage/templates/volplugin.j2
+++ b/roles/contiv_storage/templates/volplugin.j2
@@ -1,1 +1,1 @@
-VOLPLUGIN_ARGS='--debug --master {{ service_vip }}:9005'
+VOLPLUGIN_ARGS='--master {{ service_vip }}:9005'


### PR DESCRIPTION
`--debug` flag support was removed from volplugin and volmaster sometime back. Removing them from ansible now.
