### PR TITLE
fix for selinux issue-326 contiv/netplugin

### DIFF
--- a/roles/contiv_network/tasks/ovs.yml
+++ b/roles/contiv_network/tasks/ovs.yml
@@ -53,6 +53,11 @@
     - "tcp:127.0.0.1:6640"
     - "ptcp:6640"
 
+- name: permit openvswitch_t type in selinux
+  shell: >
+      semanage permissive -a openvswitch_t
+  become: true
+
 - name: setup iptables for vxlan vtep port
   shell: >
       ( iptables -L INPUT | grep "{{ netplugin_rule_comment }} ({{ item }})" ) || \

--- a/roles/contiv_network/tasks/ovs_cleanup.yml
+++ b/roles/contiv_network/tasks/ovs_cleanup.yml
@@ -25,7 +25,7 @@
 
 - debug: var=ports
 
-- name: permit openvswitch_t type in selinux
+- name: deny openvswitch_t type in selinux
   shell: >
       semanage permissive -d openvswitch_t
   become: true

--- a/roles/contiv_network/tasks/ovs_cleanup.yml
+++ b/roles/contiv_network/tasks/ovs_cleanup.yml
@@ -25,6 +25,11 @@
 
 - debug: var=ports
 
+- name: permit openvswitch_t type in selinux
+  shell: >
+      semanage permissive -d openvswitch_t
+  become: true
+
 - name: cleanup iptables for vxlan vtep port
   shell: iptables -D INPUT -p tcp --dport {{ item }} -j ACCEPT -m comment --comment "{{ netplugin_rule_comment }} ({{ item }})"
   become: true


### PR DESCRIPTION
Fix for issue #326 under contiv/netplugin .
Need to permit Selinux for openvswitch_t profile so that Selinux can not block 6633 and 6634 ports.
