### PR TITLE
adding the metadata size argument to lvcreate

### DIFF
--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -6,3 +6,4 @@ docker_version: 1.9.1
 docker_rule_comment: "docker api"
 docker_device: ""
 docker_device_size: "10000MB"
+docker_device_metadata_size: "1000MB"

--- a/roles/docker/tasks/create_docker_device.yml
+++ b/roles/docker/tasks/create_docker_device.yml
@@ -24,6 +24,6 @@
   ignore_errors: true
 
 - name: lvcreate contiv-dockerthin
-  shell: lvcreate -n dockerthin -T contiv --size {{ docker_device_size }}
+  shell: lvcreate -n dockerthin -T contiv --size {{ docker_device_size }} --poolmetadatasize {{ docker_device_metadata_size  }}
   when: lvcreated|failed
   register: thin_provisioned


### PR DESCRIPTION
Signed-off-by: Vikrant Balyan vijayvikrant84@gmail.com

The default metadata size chosen by lvcreate is very small and not sufficient.
