### PR TITLE
ucp: support for parallel multi-master bringup

### DIFF
--- a/roles/contiv_cluster/defaults/main.yml
+++ b/roles/contiv_cluster/defaults/main.yml
@@ -9,7 +9,7 @@ collins_guest_port: 9000
 clusterm_args_file: "clusterm.args"
 clusterm_conf_file: "clusterm.conf"
 
-contiv_cluster_version: "v0.0.0-04-23-2016.08-24-46.UTC"
+contiv_cluster_version: "v0.0.0-04-28-2016.22-47-57.UTC"
 contiv_cluster_tar_file: "cluster-{{ contiv_cluster_version }}.tar.bz2"
 contiv_cluster_src_file: "https://github.com/contiv/cluster/releases/download/{{ contiv_cluster_version }}/{{ contiv_cluster_tar_file }}"
 contiv_cluster_dest_file: "/tmp/{{ contiv_cluster_tar_file }}"

--- a/roles/contiv_storage/defaults/main.yml
+++ b/roles/contiv_storage/defaults/main.yml
@@ -2,7 +2,7 @@
 
 # Role defaults for contiv_storage
 
-contiv_storage_version: "v0.0.0-04-23-2016.08-28-07.UTC"
+contiv_storage_version: "v0.0.0-04-28-2016.08-29-45.UTC"
 contiv_storage_tar_file: "volplugin-{{ contiv_storage_version }}.tar.bz2"
 contiv_storage_src_file: "https://github.com/contiv/volplugin/releases/download/{{ contiv_storage_version }}/{{ contiv_storage_tar_file }}"
 contiv_storage_dest_file: "/tmp/{{ contiv_storage_tar_file }}"

--- a/roles/ucp/tasks/main.yml
+++ b/roles/ucp/tasks/main.yml
@@ -23,15 +23,6 @@
     - "{{ ucp_swarm_port }}"
     - "{{ ucp_controller_port }}"
 
-- name: copy the ucp files to worker nodes
-  copy:
-    src: "{{ ucp_local_dir }}/{{ item }}"
-    dest: "{{ ucp_remote_dir }}/{{ item }}"
-  with_items:
-    - "{{ ucp_fingerprint_file }}"
-    - "{{ ucp_instance_id_file }}"
-  when: node_name != ucp_bootstrap_node_name
-
 - name: copy the ucp license to the remote machine
   copy: src={{ ucp_license_file }} dest={{ ucp_license_remote }}
   when: (ucp_license_file is defined) and (node_name == ucp_bootstrap_node_name)
@@ -69,3 +60,12 @@
     - "{{ ucp_fingerprint_file }}"
     - "{{ ucp_instance_id_file }}"
   when: node_name == ucp_bootstrap_node_name
+
+- name: copy the ucp files to replicas and worker nodes
+  copy:
+    src: "{{ ucp_local_dir }}/{{ item }}"
+    dest: "{{ ucp_remote_dir }}/{{ item }}"
+  with_items:
+    - "{{ ucp_fingerprint_file }}"
+    - "{{ ucp_instance_id_file }}"
+  when: node_name != ucp_bootstrap_node_name

--- a/roles/ucp/templates/ucp.j2
+++ b/roles/ucp/templates/ucp.j2
@@ -12,6 +12,19 @@ start)
 
     echo starting ucp on {{ node_name }}[{{ node_addr }}]
 
+    {% if ucp_bootstrap_node_name != node_name -%}
+    # if node is running as a replica or worker make sure fingerprint file
+    # exists before procceeding
+    for true; do
+        if [ ! -f  "{{ ucp_remote_dir }}/{{ ucp_fingerprint_file }}" ]; then
+            echo `date` ": waiting for fingerprint file..."
+            sleep 2s
+        else
+            break
+        fi
+    done
+    {% endif %}
+
     {% if ucp_bootstrap_node_name == node_name -%}
     out=$(/usr/bin/docker run --rm -t --name ucp \
         -v /var/run/docker.sock:/var/run/docker.sock \
@@ -31,7 +44,7 @@ start)
     instanceId=$(echo ${out} | egrep -o 'UCP instance ID: [a-zA-Z0-9:_]*' | \
         awk --field-separator='UCP instance ID: ' '{print $2}')
     echo instance-id: $instanceId
-    echo ${instanceId} > "{{ ucp_remote_dir }}"/"{{ ucp_instance_id_file }}"
+    echo ${instanceId} > "{{ ucp_remote_dir }}/{{ ucp_instance_id_file }}"
 
     # copy out the fingerprint.
     # XXX: we store the output in variable first than redirecting
@@ -44,7 +57,7 @@ start)
     out=$(/usr/bin/docker run --rm -t --name ucp \
         -v /var/run/docker.sock:/var/run/docker.sock \
         docker/ucp fingerprint)
-    echo ${out} > "{{ ucp_remote_dir }}"/"{{ ucp_fingerprint_file }}"
+    echo ${out} > "{{ ucp_remote_dir }}/{{ ucp_fingerprint_file }}"
     {% else -%}
     /usr/bin/docker run --rm -t --name ucp \
         -v /var/run/docker.sock:/var/run/docker.sock \
@@ -57,12 +70,12 @@ start)
           --swarm-port={{ ucp_swarm_port }} --controller-port={{ ucp_controller_port }} \
           --image-version={{ ucp_version }} \
           --url="https://{{ service_vip }}:443" \
-          --fingerprint=`cat "{{ ucp_remote_dir }}"/"{{ ucp_fingerprint_file }}"`
+          --fingerprint=`cat "{{ ucp_remote_dir }}/{{ ucp_fingerprint_file }}"`
     {% endif %}
 
     # now just sleep to keep the service up
-    mkfifo "{{ ucp_remote_dir }}"/"{{ ucp_fifo_file }}"
-    < "{{ ucp_remote_dir }}"/"{{ ucp_fifo_file }}"
+    mkfifo "{{ ucp_remote_dir }}/{{ ucp_fifo_file }}"
+    < "{{ ucp_remote_dir }}/{{ ucp_fifo_file }}"
     ;;
 
 stop)


### PR DESCRIPTION
ucp replica and agents can be brought up only after fingerprint file has been generated by starting a master node. This kind of inhibits parallel multi-master bringup for ucp and till now we are forced to bringup the bootstrap node before other nodes.

This change adds a work-around in the ucp's unit file to wait for fingerprint file to be placed before trying to start ucp, which allows to make UCP master/replica bringup the process parallel. 

This will be useful now that we have multi-master support in cluster-manager.

I have also bumped the default version of contiv services, to save a separate PR :)

/cc @vvb 
