### PR TITLE
adding logging to aci-gw container

### DIFF
--- a/roles/contiv_network/templates/aci_gw.j2
+++ b/roles/contiv_network/templates/aci_gw.j2
@@ -19,6 +19,7 @@ start)
     -e "APIC_EPG_BRIDGE_DOMAIN={{ apic_epg_bridge_domain }}" \
     -e "APIC_CONTRACTS_UNRESTRICTED_MODE={{ apic_contracts_unrestricted_mode }}" \
     --name=contiv-aci-gw \
+    -v /tmp:/tmp \
     contiv/aci-gw
     ;;
 


### PR DESCRIPTION
Adding python logging to flask app. It logs everything in /tmp/aci-gw-apiagent.log file. We have to map /tmp on host to /tmp on aci-gw container then we can check logs, irrespective of container is running or not.

For this, we need to change in aci_gw.j2 template to ad -v option while running aci-gw container.
