### PR TITLE
re-enable multi netmaster instances

### DIFF
--- a/roles/contiv_network/tasks/aci_tasks.yml
+++ b/roles/contiv_network/tasks/aci_tasks.yml
@@ -1,22 +1,16 @@
 # These tasks are run when contiv_network_mode is set to aci
 
-# This task could pull a specific label, but when using latest this is not needed
 - name: pull aci-gw container
   shell: docker pull contiv/aci-gw
-  run_once: true
 
 - name: copy shell script for starting aci-gw
   template: src=aci_gw.j2 dest=/usr/bin/aci_gw.sh mode=u=rwx,g=rx,o=rx
-  run_once: true
 
 - name: copy systemd units for aci-gw
   copy: src=aci-gw.service dest=/etc/systemd/system/aci-gw.service
-  run_once: true
 
 - name: start aci-gw container
   service: name=aci-gw state=started
-  run_once: true
 
 - name: set aci mode
   shell: contivctl net global set --fabric-mode aci
-  run_once: true

--- a/roles/contiv_network/tasks/main.yml
+++ b/roles/contiv_network/tasks/main.yml
@@ -80,11 +80,9 @@
   copy: src=netmaster.service dest=/etc/systemd/system/netmaster.service
   when: run_as == "master"
 
-# resolves an issue with netmaster: https://github.com/contiv/netplugin/issues/210
 - name: start netmaster
   shell: systemctl daemon-reload && systemctl start netmaster
   when: run_as == "master"
-  run_once: true
 
 # FIXME: need to move the following tasks to correct role
 - name: download contivctl


### PR DESCRIPTION
now that netmaster supports multiple instances (https://github.com/contiv/netplugin/issues/210) we can re-enable this functionality in ansible. I think this will help netmaster's multiple instance logic get tested more often in net-demo-installer and clusterm based environments.

/cc @shaleman , please let me know if you think this will not work or see any other issues. In a basic cluster-manager demo setup, I am able to verify that multiple netmaster instances come up fine and a network create/list operation went fine.
