### PR TITLE
enabling ceph to work with iptables

### DIFF
--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -7,6 +7,10 @@
 
 fetch_directory: fetch/
 
+port_ceph_mon: 6789
+port_range_ceph_osd: 6800:7300
+ceph_rule_comment: "ceph traffic"
+
 ###########
 # INSTALL #
 ###########

--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -97,3 +97,15 @@
     owner: root
     group: root
     mode: 0644
+
+- name: setup iptables for ceph_mon
+  shell: >
+      ( iptables -L INPUT | grep "{{ ceph_rule_comment }} ({{ port_ceph_mon }})" ) || \
+      iptables -I INPUT 1 -p tcp --dport {{ port_ceph_mon }} -j ACCEPT -m comment --comment "{{ ceph_rule_comment }} ({{ port_ceph_mon }})"
+  become: true
+
+- name: setup iptables for ceph_osd
+  shell: >
+      ( iptables -L INPUT | grep "{{ ceph_rule_comment }} ({{ port_range_ceph_osd }})" ) || \
+      iptables -I INPUT 1 -p tcp -m multiport --dports {{ port_range_ceph_osd }} -j ACCEPT -m comment --comment "{{ ceph_rule_comment }} ({{ port_range_ceph_osd }})"
+  become: true


### PR DESCRIPTION
The changes are made as per http://docs.ceph.com/docs/master/rados/configuration/network-config-ref/
