### PR TITLE
Aci logging

### DIFF
--- a/roles/contiv_network/templates/aci_gw.j2
+++ b/roles/contiv_network/templates/aci_gw.j2
@@ -10,7 +10,7 @@ case $1 in
 start)
     set -e
 
-    /usr/bin/docker run --net=host \
+    /usr/bin/docker run -t --net=host \
     -e "APIC_URL={{ apic_url }}" \
     -e "APIC_USERNAME={{ apic_username }}" \
     -e "APIC_PASSWORD={{ apic_password }}" \


### PR DESCRIPTION
Adding -t option while starting aci-gw container. So that we can inspect logs of this container by doing docker logs -f aci-gw.

Right now because -t option is not present , whatever is getting printed at stdin in apiagent.py file, is not getting printed.
