### PR TITLE
fixes for ucp 1.1.0

### DIFF
--- a/roles/ucp/defaults/main.yml
+++ b/roles/ucp/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # Role defaults for ucp
 
-ucp_version: "1.0.4"
+ucp_version: "1.1.0"
 ucp_local_dir: "fetch/ucp"
 ucp_remote_dir: "/tmp"
 ucp_instance_id_file: "ucp-instance-id"
@@ -17,6 +17,11 @@ ucp_port2: "12379"
 ucp_port3: "12380"
 ucp_port4: "12381"
 ucp_port5: "12382"
+ucp_port6: "12383"
+ucp_port7: "12384"
+ucp_port8: "12385"
+ucp_port9: "12386"
+ucp_hb_port: "2375"
 ucp_swarm_port: "2376"
 ucp_controller_port: "443"
 ucp_swarm_strategy: "spread"

--- a/roles/ucp/tasks/cleanup.yml
+++ b/roles/ucp/tasks/cleanup.yml
@@ -11,6 +11,12 @@
     - "{{ ucp_instance_id_file }}"
     - "{{ ucp_fifo_file }}"
 
+# XXX: temporary fix for issue with ucp 1.1.0 where it doesn't cleanup this file
+# remove this once it is fixed. Target fix version is 1.1.2
+- name: cleanup ucp generated docker config file
+  file: name=/etc/docker/daemon.json state=absent
+  become: true
+
 - name: cleanup iptables for ucp
   shell: iptables -D INPUT -p tcp --dport {{ item }} -j ACCEPT -m comment --comment "{{ ucp_rule_comment }} ({{ item }})"
   become: true
@@ -20,5 +26,10 @@
     - "{{ ucp_port3 }}"
     - "{{ ucp_port4 }}"
     - "{{ ucp_port5 }}"
+    - "{{ ucp_port6 }}"
+    - "{{ ucp_port7 }}"
+    - "{{ ucp_port8 }}"
+    - "{{ ucp_port9 }}"
+    - "{{ ucp_hb_port }}"
     - "{{ ucp_swarm_port }}"
     - "{{ ucp_controller_port }}"

--- a/roles/ucp/tasks/main.yml
+++ b/roles/ucp/tasks/main.yml
@@ -20,6 +20,11 @@
     - "{{ ucp_port3 }}"
     - "{{ ucp_port4 }}"
     - "{{ ucp_port5 }}"
+    - "{{ ucp_port6 }}"
+    - "{{ ucp_port7 }}"
+    - "{{ ucp_port8 }}"
+    - "{{ ucp_port9 }}"
+    - "{{ ucp_hb_port }}"
     - "{{ ucp_swarm_port }}"
     - "{{ ucp_controller_port }}"
 

--- a/roles/ucp/templates/ucp.j2
+++ b/roles/ucp/templates/ucp.j2
@@ -36,14 +36,14 @@ start)
     {% if ucp_swarm_strategy != "spread" -%}
           --{{ ucp_swarm_strategy }} \
     {% endif -%}
-          --image-version={{ ucp_version }} | tee /tmp/ucp.log)
+          --image-version={{ ucp_version }} --fresh-install | tee /tmp/ucp.log)
 
     cat /tmp/ucp.log
     rm /tmp/ucp.log
     # copy out the instance ID
     instanceId=$(echo ${out} | egrep -o 'UCP instance ID: [a-zA-Z0-9:_]*' | \
         awk --field-separator='UCP instance ID: ' '{print $2}')
-    echo instance-id: $instanceId
+    echo instance-id: ${instanceId}
     echo ${instanceId} > "{{ ucp_remote_dir }}/{{ ucp_instance_id_file }}"
 
     # copy out the fingerprint.
@@ -54,10 +54,13 @@ start)
     # XXX: we need a way for this fingerprint to stick around wherever
     # contiv/cluster service is running. May be we can save this file on a
     # distributed filesystem
-    out=$(/usr/bin/docker run --rm -t --name ucp \
+    out=$(/usr/bin/docker run --rm --name ucp \
         -v /var/run/docker.sock:/var/run/docker.sock \
         docker/ucp fingerprint)
-    echo ${out} > "{{ ucp_remote_dir }}/{{ ucp_fingerprint_file }}"
+    fingerprint=$(echo ${out} | egrep -o 'Fingerprint=[a-zA-Z0-9:]*' | \
+        awk --field-separator='=' '{print $2}')
+    echo fingerprint: ${fingerprint}
+    echo ${fingerprint} > "{{ ucp_remote_dir }}/{{ ucp_fingerprint_file }}"
     {% else -%}
     /usr/bin/docker run --rm -t --name ucp \
         -v /var/run/docker.sock:/var/run/docker.sock \
@@ -86,6 +89,9 @@ stop)
 
     #remove the ucp containers and associated volumes
     docker ps -a | grep 'ucp-' | awk '{print $1}' | xargs docker rm -v
+
+    #explicitly try and remove ucp volumes (in case they were left over)
+    docker volume ls | grep ucp-* | awk '{print $2}' | xargs docker volume rm
 
     # XXX: do we need to uninstall ucp too?
     #/usr/bin/docker run --rm -t --name ucp \


### PR DESCRIPTION
- add the new ucp ports to iptables
- added more cleanup handling that tries to remove docker volumes associated with ucp
- added --fresh-install flag for ucp start to make install more reliable
- also added a temporary fix to cleanup UCP generated docker config when the service is cleaned up. The fix for this is expected to be available in UCP v1.1.2

fixes #189 

/cc @rkharya . 

This seems to be working for me, please try it out in your setup as well and let me know if doesn't for you.
