### PR TITLE
rdo-release-kilo-2.noarch.rpm

### DIFF
--- a/roles/contiv_network/tasks/ovs.yml
+++ b/roles/contiv_network/tasks/ovs.yml
@@ -2,7 +2,7 @@
 # This role contains tasks for installing ovs
 
 - name: install openstack kilo repo (redhat)
-  yum: "name=https://repos.fedorapeople.org/repos/openstack/openstack-kilo/rdo-release-kilo-1.noarch.rpm"
+  yum: "name=https://repos.fedorapeople.org/repos/openstack/openstack-kilo/rdo-release-kilo-2.noarch.rpm"
   when: ansible_os_family == "RedHat"
   tags:
     - prebake-for-dev


### PR DESCRIPTION
rdo-release-kilo-1.noarch.rpm is now rdo-release-kilo-2.noarch.rpm
