### PR TITLE
move ovs 2.3 installation for Centos 7.2 to RPM published in cisco box

### DIFF
--- a/roles/contiv_cluster/defaults/main.yml
+++ b/roles/contiv_cluster/defaults/main.yml
@@ -9,7 +9,7 @@ collins_guest_port: 9000
 clusterm_args_file: "clusterm.args"
 clusterm_conf_file: "clusterm.conf"
 
-contiv_cluster_version: "v0.0.0-05-05-2016.17-17-13.UTC"
+contiv_cluster_version: "v0.1-05-12-2016.08-27-16.UTC"
 contiv_cluster_tar_file: "cluster-{{ contiv_cluster_version }}.tar.bz2"
 contiv_cluster_src_file: "https://github.com/contiv/cluster/releases/download/{{ contiv_cluster_version }}/{{ contiv_cluster_tar_file }}"
 contiv_cluster_dest_file: "/tmp/{{ contiv_cluster_tar_file }}"

--- a/roles/contiv_network/defaults/main.yml
+++ b/roles/contiv_network/defaults/main.yml
@@ -16,7 +16,7 @@ bgp_port: 179
 vxlan_port: 4789
 netplugin_rule_comment: "contiv network traffic"
 
-contiv_network_version: "v0.1-05-05-2016.18-38-56.UTC"
+contiv_network_version: "v0.1-05-08-2016.20-28-46.UTC"
 contiv_network_tar_file: "netplugin-{{ contiv_network_version }}.tar.bz2"
 contiv_network_src_file: "https://github.com/contiv/netplugin/releases/download/{{ contiv_network_version }}/{{ contiv_network_tar_file }}"
 contiv_network_dest_file: "/tmp/{{ contiv_network_tar_file }}"

--- a/roles/contiv_network/tasks/ovs.yml
+++ b/roles/contiv_network/tasks/ovs.yml
@@ -1,14 +1,22 @@
 ---
 # This role contains tasks for installing ovs
 
-- name: install openstack kilo repo (redhat)
-  yum: "name=https://repos.fedorapeople.org/repos/openstack/openstack-kilo/rdo-release-kilo-2.noarch.rpm"
+- name: download ovs binaries (redhat)
+  get_url:
+    validate_certs: "{{ validate_certs }}"
+    dest: "{{ item.dest }}"
+    url: "{{ item.url }}"
+  with_items:
+    - {
+        url: "https://cisco.box.com/shared/static/51eo9dcw04qx2y1f14n99y4yt5kug3q4.rpm",
+        dest: /tmp/openvswitch-2.3.1-1.x86_64.rpm
+      }
   when: ansible_os_family == "RedHat"
   tags:
     - prebake-for-dev
 
 - name: install ovs (redhat)
-  yum: name=openvswitch state=present
+  yum: name=/tmp/openvswitch-2.3.1-1.x86_64.rpm state=present
   when: ansible_os_family == "RedHat"
   tags:
     - prebake-for-dev

--- a/roles/contiv_storage/defaults/main.yml
+++ b/roles/contiv_storage/defaults/main.yml
@@ -2,7 +2,7 @@
 
 # Role defaults for contiv_storage
 
-contiv_storage_version: "v0.0.0-05-05-2016.08-24-25.UTC"
+contiv_storage_version: "v0.0.0-05-12-2016.08-24-33.UTC"
 contiv_storage_tar_file: "volplugin-{{ contiv_storage_version }}.tar.bz2"
 contiv_storage_src_file: "https://github.com/contiv/volplugin/releases/download/{{ contiv_storage_version }}/{{ contiv_storage_tar_file }}"
 contiv_storage_dest_file: "/tmp/{{ contiv_storage_tar_file }}"


### PR DESCRIPTION
- openstack-kilo repo has a few issues like it installs ovs 2.4 (netplugin is not validated with that version) and also that repo doesn't seem to work with RedHat.
- also bumping up the version of contiv services

I will also publish a packer box soon after this is merged.
