### PR TITLE
run etcd inside a container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: test-up test-provision test-cleanup
+
+test-up:
+	vagrant up
+
+test-provision:
+	vagrant provision
+
+test-cleanup:
+	CONTIV_ANSIBLE_PLAYBOOK="./cleanup.yml" CONTIV_ANSIBLE_TAGS="all" vagrant provision

--- a/cleanup.yml
+++ b/cleanup.yml
@@ -20,7 +20,7 @@
         - contiv_storage
         - swarm
         - ucp
-        - docker
         - etcd
         - ucarp
+        - docker
       ignore_errors: yes

--- a/roles/dev/meta/main.yml
+++ b/roles/dev/meta/main.yml
@@ -14,8 +14,8 @@
 dependencies:
 - { role: ceph-install, tags: 'prebake-for-dev' }
 - { role: ansible, tags: 'prebake-for-dev' }
-- { role: etcd }
 - { role: docker }
+- { role: etcd }
 - { role: swarm }
 - { role: ucp }
 - { role: contiv_cluster }

--- a/roles/etcd/files/etcd.service
+++ b/roles/etcd/files/etcd.service
@@ -1,9 +1,10 @@
 [Unit]
 Description=Etcd
-After=auditd.service systemd-user-sessions.service time-sync.target
+After=auditd.service systemd-user-sessions.service time-sync.target docker.service
+Requires=docker.service
 
 [Service]
+Restart=on-failure
 ExecStart=/usr/bin/etcd.sh start
 ExecStop=/usr/bin/etcd.sh stop
 KillMode=control-group
-ExecStopPost=/usr/bin/etcd.sh post-stop

--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 # This role contains tasks for configuring and starting etcd service
 
-- name: download etcd {{ etcd_version }}
+- name: download etcdctl {{ etcd_version }}
   get_url:
     validate_certs: "{{ validate_certs }}"
     url: https://github.com/coreos/etcd/releases/download/{{ etcd_version }}/etcd-{{ etcd_version }}-linux-amd64.tar.gz
@@ -9,10 +9,15 @@
   tags:
     - prebake-for-dev
 
-- name: install etcd
+- name: install etcdctl
   shell: >
       tar vxzf /tmp/etcd-{{ etcd_version }}-linux-amd64.tar.gz && \
       mv etcd-{{ etcd_version }}-linux-amd64/etcd* /usr/bin
+  tags:
+    - prebake-for-dev
+
+- name: install etcd {{ etcd_version }}
+  shell: docker pull quay.io/coreos/etcd:{{ etcd_version }}
   tags:
     - prebake-for-dev
 

--- a/roles/etcd/templates/etcd.j2
+++ b/roles/etcd/templates/etcd.j2
@@ -135,7 +135,20 @@ start)
 
     #start etcd
     echo "==> starting etcd with environment:" `env`
-    /usr/bin/etcd
+    /usr/bin/docker run -t --rm --net=host --name etcd \
+        -e ETCD_NAME=${ETCD_NAME} \
+        -e ETCD_DATA_DIR=${ETCD_DATA_DIR} \
+        -e ETCD_INITIAL_CLUSTER_TOKEN=${ETCD_INITIAL_CLUSTER_TOKEN} \
+        -e ETCD_LISTEN_CLIENT_URLS=${ETCD_LISTEN_CLIENT_URLS} \
+        -e ETCD_ADVERTISE_CLIENT_URLS=${ETCD_ADVERTISE_CLIENT_URLS} \
+        -e ETCD_INITIAL_ADVERTISE_PEER_URLS=${ETCD_INITIAL_ADVERTISE_PEER_URLS} \
+        -e ETCD_LISTEN_PEER_URLS=${ETCD_LISTEN_PEER_URLS} \
+        -e ETCD_HEARTBEAT_INTERVAL=${ETCD_HEARTBEAT_INTERVAL} \
+        -e ETCD_ELECTION_TIMEOUT=${ETCD_ELECTION_TIMEOUT} \
+        -e ETCD_INITIAL_CLUSTER=${ETCD_INITIAL_CLUSTER} \
+        -e ETCD_INITIAL_CLUSTER_STATE=${ETCD_INITIAL_CLUSTER_STATE} \
+        -e ETCD_PROXY=${ETCD_PROXY} \
+        quay.io/coreos/etcd:{{ etcd_version }}
     ;;
 
 stop)
@@ -152,11 +165,9 @@ stop)
     {% else -%}
     {{ remove_member(peer_addr=etcd_master_addr) }}
     {% endif -%}
-    ;;
 
-post-stop)
-    #XXX: is there a case when we should not cleanup the data dir on stop?
-    rm -rf $ETCD_DATA_DIR
+    /usr/bin/docker stop etcd
+    /usr/bin/docker rm etcd
     ;;
 
 *)

--- a/site.yml
+++ b/site.yml
@@ -23,8 +23,8 @@
   - { role: nfs }
   - { role: vagrant }
   - { role: ucarp }
-  - { role: etcd, run_as: master }
   - { role: docker, etcd_client_port1: 2379 }
+  - { role: etcd, run_as: master }
   - { role: ceph-mon, mon_group_name: volplugin-test }
   - { role: ceph-osd, mon_group_name: volplugin-test, osd_group_name: volplugin-test }
   - { role: scheduler_stack, run_as: master }
@@ -87,7 +87,7 @@
   environment: '{{ env }}'
   roles:
   - { role: base }
-  - { role: etcd, run_as: master }
   - { role: docker, etcd_client_port1: 2379 }
+  - { role: etcd, run_as: master }
   - { role: scheduler_stack, run_as: master }
   - { role: contiv_network, run_as: master }


### PR DESCRIPTION
there are no changes to the etcd setup logic other than it's dependency on docker now. Basic testing shows it works fine.

Note that we still download the corresponding etcd release binaries (along with container images) to get etcdctl.

I have also added a Makefile for common ansible test targets.

/cc @erikh @vvb 
