### PR TITLE
temporarily use netctl for setting aci mode

### DIFF
--- a/roles/contiv_network/tasks/aci_tasks.yml
+++ b/roles/contiv_network/tasks/aci_tasks.yml
@@ -12,5 +12,6 @@
 - name: start aci-gw container
   service: name=aci-gw state=started
 
+# XXX: revert this to use contivctl once https://github.com/contiv/contivctl/issues/3 is fixed
 - name: set aci mode
-  shell: contivctl net global set --fabric-mode aci
+  shell: netctl global set --fabric-mode aci


### PR DESCRIPTION
this is to temporarily address part of https://github.com/contiv/netplugin/issues/388 caused by outdated contivctl while we work on the fix for https://github.com/contiv/contivctl/issues/3

/cc @erikh @rkharya @shaleman 
