### PR TITLE
Misc fixes and enhancements

### DIFF
--- a/roles/contiv_network/files/netplugin.service
+++ b/roles/contiv_network/files/netplugin.service
@@ -5,4 +5,5 @@ After=auditd.service systemd-user-sessions.service time-sync.target etcd.service
 [Service]
 EnvironmentFile=/etc/default/netplugin
 ExecStart=/usr/bin/netplugin $NETPLUGIN_ARGS
+ExecStopPost=/usr/bin/rm -f /run/docker/plugins/netplugin.sock
 KillMode=control-group

--- a/roles/contiv_storage/files/volplugin.service
+++ b/roles/contiv_storage/files/volplugin.service
@@ -5,4 +5,5 @@ After=auditd.service systemd-user-sessions.service time-sync.target etcd.service
 [Service]
 EnvironmentFile=/etc/default/volplugin
 ExecStart=/usr/bin/volplugin $VOLPLUGIN_ARGS
+ExecStopPost=/usr/bin/rm -f /run/docker/plugins/volplugin.sock
 KillMode=control-group

--- a/roles/etcd/files/etcd.service
+++ b/roles/etcd/files/etcd.service
@@ -1,10 +1,10 @@
 [Unit]
 Description=Etcd
 After=auditd.service systemd-user-sessions.service time-sync.target docker.service
-Requires=docker.service
 
 [Service]
 Restart=on-failure
+RestartSec=10s
 ExecStart=/usr/bin/etcd.sh start
 ExecStop=/usr/bin/etcd.sh stop
 KillMode=control-group

--- a/roles/etcd/templates/etcd.j2
+++ b/roles/etcd/templates/etcd.j2
@@ -15,7 +15,7 @@ http://{{ addr }}:{{ etcd_client_port1 }},http://{{ addr }}:{{ etcd_client_port2
 {%- macro get_peer_addr() -%}
     {# we can't use a simple filter as shown, as it needs python 2.8.
      # So resorting to loop below to get a peer.
-    {%- set peer_name=groups[etcd_peers_group]|reject("equalto", node_name)|first -%} #}
+     #{%- set peer_name=groups[etcd_peers_group]|reject("equalto", node_name)|first -%} #}
     {%- set peers=[] -%}
     {%- for host in groups[etcd_peers_group] -%}
         {%- if host != node_name -%}
@@ -124,6 +124,15 @@ export ETCD_ELECTION_TIMEOUT={{ etcd_election_timeout }}
 set -x
 case $1 in
 start)
+    # check if docker is running, else fail early.
+    # this is done instead of adding a 'Requires' dependency for docker in
+    # unit file to ensure that the etcd service starts as soon as docker starts
+    # even after a manual restart of docker.
+    out=$(/usr/bin/docker ps 2>&1 | grep -o "Cannot connect to the Docker daemon")
+    if [ "${out}" == "Cannot connect to the Docker daemon" ]; then
+        echo "docker is not running."
+        exit 1
+    fi
     {% if run_as == "worker" -%}
     {{ add_proxy() }}
     {% elif etcd_init_cluster -%}
@@ -158,7 +167,6 @@ stop)
         {% set peer_addr=get_peer_addr() -%}
         {% if peer_addr == "" -%}
         echo "==> no peer found or single member cluster at time of commission"
-        exit 1
         {% else -%}
         {{ remove_member(peer_addr=peer_addr) }}
         {% endif %}

--- a/roles/ucp/tasks/cleanup.yml
+++ b/roles/ucp/tasks/cleanup.yml
@@ -9,7 +9,6 @@
   with_items:
     - "{{ ucp_fingerprint_file }}"
     - "{{ ucp_instance_id_file }}"
-    - "{{ ucp_fifo_file }}"
 
 # XXX: temporary fix for issue with ucp 1.1.0 where it doesn't cleanup this file
 # remove this once it is fixed. Target fix version is 1.1.2

--- a/roles/ucp/templates/ucp.j2
+++ b/roles/ucp/templates/ucp.j2
@@ -92,6 +92,9 @@ start)
 stop)
     # don't `set -e` as we shouldn't stop on error
 
+    #remove the fifo file
+    rm -f "{{ ucp_remote_dir }}/{{ ucp_fifo_file }}"
+
     #stop the ucp containers and associated volumes
     docker ps -a | grep 'ucp-' | awk '{print $1}' | xargs docker stop
 


### PR DESCRIPTION
Overview:
- ucp: remove the fifo file as part of ucp service stop, this ensures that ucp service can be restarted on failure or manual restart
- etcd:
  - remove Requires attribute from etcd unit
    - this ensures that systemd tries to restart etcd even when docker service is manually restarted.
  - set RestartSec for etcd service to prevent etcd unit being restarted too fast
  - exit early on service start if docker is not running
  - remove an un-needed exit from etcd stop script
- netplugin/volplugin: cleanup the socket files when service is stopped
