### PR TITLE
Misc fixes and enhancements

### DIFF
--- a/cleanup.yml
+++ b/cleanup.yml
@@ -4,7 +4,7 @@
 # Note: cleanup is not expected to fail, so we set ignore_errors to yes here
 
 - hosts: all
-  sudo: true
+  become: true
   tasks:
     - include_vars: roles/{{ item }}/defaults/main.yml
       with_items:

--- a/roles/base/tasks/redhat_tasks.yml
+++ b/roles/base/tasks/redhat_tasks.yml
@@ -19,6 +19,8 @@
     - bash-completion
     - kernel #keep kernel up to date
     - libselinux-python
+    - e2fsprogs
+    - openssh-server
 
 - name: install and start ntp
   service: name=ntpd state=started enabled=yes

--- a/roles/base/tasks/ubuntu_tasks.yml
+++ b/roles/base/tasks/ubuntu_tasks.yml
@@ -15,3 +15,5 @@
     - python-software-properties
     - bash-completion
     - python-selinux
+    - e2fsprogs
+    - openssh-server

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -33,7 +33,6 @@
   shell: >
       ( iptables -L INPUT | grep "{{ docker_rule_comment }} ({{ item }})" ) || \
       iptables -I INPUT 1 -p tcp --dport {{ item }} -j ACCEPT -m comment --comment "{{ docker_rule_comment }} ({{ item }})"
-  become: true
   with_items:
     - "{{ docker_api_port }}"
 
@@ -59,7 +58,7 @@
 
   # tcp socket service requires docker service to be started after it
 - name: reload systemd configuration
-  shell: sudo systemctl daemon-reload
+  shell: systemctl daemon-reload
   when: "(docker_tcp_socket | changed) or (docker_tcp_socket_state.stdout != 'Active: active')"
 
 - name: stop docker
@@ -75,7 +74,7 @@
   when: "(docker_tcp_socket | changed) or (docker_tcp_socket_state.stdout != 'Active: active')"
 
 - name: check docker service state
-  shell: sudo systemctl status docker | grep 'Active.*active' -o
+  shell: systemctl status docker | grep 'Active.*active' -o
   ignore_errors: true
   register: docker_service_state
   tags:
@@ -89,7 +88,7 @@
 # https://github.com/ansible/ansible-modules-core/issues/191
 - name: reload docker systemd configuration
   #service: name=docker state=restarted
-  shell: sudo systemctl daemon-reload
+  shell: systemctl daemon-reload
   when: "(docker_service_state.stderr | match('.*docker.service changed on disk.*')) or (docker_service_state.stdout != 'Active: active')"
   tags:
     - prebake-for-dev

--- a/roles/test/defaults/main.yml
+++ b/roles/test/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+# role variable for the test environment packages
+
+vbox_major_version: "5.0.20"
+vbox_version: "5.0-{{ vbox_major_version }}_106931"
+vagrant_version: "1.8.1"
+packer_version: "0.10.0"

--- a/roles/test/tasks/os_agnostic_tasks.yml
+++ b/roles/test/tasks/os_agnostic_tasks.yml
@@ -1,18 +1,18 @@
 - name: check packer's version
   shell: packer --version
-  register: packer_version
+  register: packer_installed_version
   ignore_errors: yes
 
 - name: download packer
   get_url:
     validate_certs: "{{ validate_certs }}"
-    url: https://releases.hashicorp.com/packer/0.8.6/packer_0.8.6_linux_amd64.zip
-    dest: /tmp/packer_0.8.6_linux_amd64.zip
+    url: "https://releases.hashicorp.com/packer/{{ packer_version }}/packer_{{ packer_version }}_linux_amd64.zip"
+    dest: "/tmp/packer_{{ packer_version }}_linux_amd64.zip"
     force: no
-  when: packer_version.stdout != "0.8.6"
+  when: packer_installed_version.stdout != "{{ packer_version }}"
 
 - name: install packer
-  shell: rm -f packer* && unzip /tmp/packer_0.8.6_linux_amd64.zip
+  shell: rm -f packer* && unzip /tmp/packer_{{ packer_version }}_linux_amd64.zip
   args:
     chdir: /usr/local/bin
-  when: packer_version.stdout != "0.8.6"
+  when: packer_installed_version.stdout != "{{ packer_version }}"

--- a/roles/test/tasks/redhat_tasks.yml
+++ b/roles/test/tasks/redhat_tasks.yml
@@ -1,12 +1,12 @@
 - name: download VBox (redhat)
   get_url:
     validate_certs: "{{ validate_certs }}"
-    url: http://download.virtualbox.org/virtualbox/5.0.12/VirtualBox-5.0-5.0.12_104815_el7-1.x86_64.rpm
-    dest: /tmp/VirtualBox-5.0-5.0.12_104815_el7-1.x86_64.rpm
+    url: http://download.virtualbox.org/virtualbox/{{ vbox_major_version }}/VirtualBox-{{ vbox_version }}_el7-1.x86_64.rpm
+    dest: /tmp/VirtualBox-{{ vbox_major_version }}.rpm
     force: no
 
 - name: install VBox (redhat)
-  yum: name=/tmp/VirtualBox-5.0-5.0.12_104815_el7-1.x86_64.rpm state=present
+  yum: name=/tmp/VirtualBox-{{ vbox_major_version }}.rpm state=present
 
 - name: install VBox dkms and dependencies (redhat)
   yum: name={{ item }} state=latest
@@ -25,9 +25,9 @@
 - name: download vagrant (redhat)
   get_url:
     validate_certs: "{{ validate_certs }}"
-    url: https://releases.hashicorp.com/vagrant/1.8.1/vagrant_1.8.1_x86_64.rpm
-    dest: /tmp/vagrant_1.8.1_x86_64.rpm
+    url: https://releases.hashicorp.com/vagrant/{{ vagrant_version }}/vagrant_{{ vagrant_version }}_x86_64.rpm
+    dest: /tmp/vagrant_{{ vagrant_version }}.rpm
     force: no
 
 - name: install vagrant (redhat)
-  yum: name=/tmp/vagrant_1.8.1_x86_64.rpm state=present
+  yum: name=/tmp/vagrant_{{ vagrant_version }}.rpm state=present

--- a/roles/test/tasks/ubuntu_tasks.yml
+++ b/roles/test/tasks/ubuntu_tasks.yml
@@ -1,22 +1,22 @@
 - name: download VBox (debian)
   get_url:
     validate_certs: "{{ validate_certs }}"
-    url: http://download.virtualbox.org/virtualbox/5.0.12/virtualbox-5.0_5.0.12-104815~Ubuntu~trusty_amd64.deb
-    dest: /tmp/virtualbox-5.0_5.0.12-104815~Ubuntu~trusty_amd64.deb
+    url: http://download.virtualbox.org/virtualbox/{{ vbox_major_version }}/virtualbox-{{ vbox_version }}~{{ ansible_distribution }}~{{ ansible_distribution_release }}_amd64.deb
+    dest: /tmp/virtualbox-{{ vbox_major_version }}.deb
     force: no
 
 - name: install VBox (debian)
-  apt: deb=/tmp/virtualbox-5.0_5.0.12-104815~Ubuntu~trusty_amd64.deb state=present
+  apt: deb=/tmp/virtualbox-{{ vbox_major_version }}.deb state=present
 
 - name: install VBox dkms (debian)
-  apt: name=dkms state=present
+  apt: name=dkms state=latest
 
 - name: download vagrant (debian)
   get_url:
     validate_certs: "{{ validate_certs }}"
-    url: https://releases.hashicorp.com/vagrant/1.8.1/vagrant_1.8.1_x86_64.deb
-    dest: /tmp/vagrant_1.8.1_x86_64.deb
+    url: https://releases.hashicorp.com/vagrant/1.8.1/vagrant_{{ vagrant_version }}_x86_64.deb
+    dest: /tmp/vagrant_{{ vagrant_version }}.deb
     force: no
 
 - name: install vagrant (debian)
-  apt: deb=/tmp/vagrant_1.8.1_x86_64.deb state=present
+  apt: deb=/tmp/vagrant_{{ vagrant_version }}.deb state=present

--- a/site.yml
+++ b/site.yml
@@ -8,7 +8,7 @@
 # - pre-bake some binaries that are otherwise installed as part of contiv
 #   service deployments like collins, sky-dns, ceph etc.
 - hosts: devtest
-  sudo: true
+  become: true
   environment: '{{ env }}'
   roles:
   - { role: base }
@@ -16,7 +16,7 @@
   - { role: test }
 
 - hosts: volplugin-test
-  sudo: true
+  become: true
   environment: '{{ env }}'
   roles: 
   - { role: base }
@@ -34,7 +34,7 @@
 # This host group shall provision a host with all required packages needed to make
 # the node ready to be managed by cluster-manager
 - hosts: cluster-node
-  sudo: true
+  become: true
   environment: '{{ env }}'
   roles:
   - { role: base }
@@ -43,7 +43,7 @@
 # cluster-control hosts corresponds to the first machine in the cluster that is provisioned
 # to bootstrap the cluster by starting cluster manager and inventory database (collins)
 - hosts: cluster-control
-  sudo: true
+  become: true
   environment: '{{ env }}'
   roles:
   - { role: base }
@@ -54,7 +54,7 @@
 # service-master hosts correspond to cluster machines that run the master/controller
 # logic of the infra services
 - hosts: service-master
-  sudo: true
+  become: true
   environment: '{{ env }}'
   roles:
   - { role: base }
@@ -70,7 +70,7 @@
 # service-worker hosts correspond to cluster machines that run the worker/driver
 # logic of the infra services.
 - hosts: service-worker
-  sudo: true
+  become: true
   environment: '{{ env }}'
   roles:
   - { role: base }
@@ -83,7 +83,7 @@
 
 # netplugin-node hosts set up netmast/netplugin in a cluster
 - hosts: netplugin-node
-  sudo: true
+  become: true
   environment: '{{ env }}'
   roles:
   - { role: base }


### PR DESCRIPTION
- install a few base packages
  - e2fsprogs that provides mkfs.ext4 needed by docker
  - openssh-server provides sshd needed when provisioning a container. It is otherwise should already be installed.
- use 'become' in place of 'sudo', to cut on a few warnings
- use version variables for vbox, vagrant and packer

This is a preliminary patch that will enable us to use ansible to generate container images for CI, but I think it is a good to have patch in general.
