### PR TITLE
add a host entry with control-ip and hostname

### DIFF
--- a/roles/contiv_network/tasks/main.yml
+++ b/roles/contiv_network/tasks/main.yml
@@ -21,7 +21,6 @@
   shell: >
       ( iptables -L INPUT | grep "{{ netplugin_rule_comment }} ({{ item }})" ) || \
       iptables -I INPUT 1 -p tcp --dport {{ item }} -j ACCEPT -m comment --comment "{{ netplugin_rule_comment }} ({{ item }})"
-  become: true
   with_items:
     - "{{ ofnet_master_port }}"
     - "{{ ofnet_agent_port1 }}"
@@ -70,7 +69,17 @@
     line: "{{ service_vip }} netmaster"
     regexp: " netmaster$"
     state: present
-  become: true
+
+# XXX: remove this task once the following is resolved: https://github.com/contiv/netplugin/issues/275
+- name: setup hostname alias
+  lineinfile:
+    dest: /etc/hosts
+    line: "{{ item.line }}"
+    regexp: "{{ item.regexp }}"
+    state: present
+  with_items:
+    - { line: '127.0.0.1 localhost', regexp: '^127\.0\.0\.1' }
+    - { line: '{{ node_addr }} {{ ansible_hostname }}', regexp: ' {{ ansible_hostname }}$' }
 
 - name: copy environment file for netmaster
   copy: src=netmaster dest=/etc/default/netmaster


### PR DESCRIPTION
The following snippet shows how host file looks like before and after this task is run:

```
[vagrant@host0 ~]$ cat /etc/hosts
127.0.0.1   host0 localhost localhost.localdomain localhost4 localhost4.localdomain4
::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
[vagrant@host0 ~]$
[vagrant@host0 ~]$ cat /etc/hosts
127.0.0.1 localhost
::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
192.168.3.252 netmaster
192.168.3.10 host0
[vagrant@host0 ~]$
```

I also removed a few extra `become: true` in this file, which are not needed.

/cc @shaleman 

fixes #220 
