### PR TITLE
fix for ucp failure while importing certs

### DIFF
--- a/roles/ucp/templates/ucp.j2
+++ b/roles/ucp/templates/ucp.j2
@@ -93,7 +93,7 @@ start)
 
     {% if run_as == "master" -%}
     # On non-bootstrap master nodes, restore ucp certificates
-    /usr/bin/docker run -it --rm --name ucp \
+    /usr/bin/docker run -i --rm --name ucp \
         -v /var/run/docker.sock:/var/run/docker.sock \
         docker/ucp restore --root-ca-only --passphrase "{{ ucp_cert_secret }}" \
         --id `cat "{{ ucp_remote_dir }}/{{ ucp_instance_id_file }}"` \


### PR DESCRIPTION
This fixes the ucp failure caused by

```
Jun 10 00:12:59 ucsb-blade3 ucp.sh[54685]: cannot enable tty mode on non tty input
```
