### PR TITLE
force download of docker-compose when out of version

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -131,6 +131,7 @@
     url: https://github.com/docker/compose/releases/download/{{ docker_compose_version }}/docker-compose-{{ ansible_system }}-{{ ansible_userspace_architecture }}
     dest: /usr/bin/docker-compose
     mode: u=rwx,g=rx,o=rx
+    force: yes
   when: not (docker_compose_installed_version.stdout | match('docker-compose version {{ docker_compose_version }},.*'))
   tags:
     - prebake-for-dev


### PR DESCRIPTION
Signed-off-by: Vikrant Balyan vijayvikrant84@gmail.com

without the `force` parameter, `get_url` will not download file if the `dest` is a file and it already exists. Generally `force==yes` is not advisable when the download is over the internet, but in this specific scenario we have a `when` that will protect us from cases where we should not be forcing download.
