### PR TITLE
simplify etcd deploy scripts

### DIFF
--- a/roles/etcd/defaults/main.yml
+++ b/roles/etcd/defaults/main.yml
@@ -6,14 +6,7 @@ etcd_client_port2: 4001
 etcd_peer_port1: 2380
 etcd_peer_port2: 7001
 etcd_peers_group: "service-master"
-etcd_init_cluster: true
 etcd_rule_comment: "etcd traffic"
 etcd_version: "v2.3.1"
 etcd_heartbeat_interval: 1000
 etcd_election_timeout: 10000
-
-# following variables are used in one or more roles, but have no good default value to pick from.
-# Leaving them as commented so that playbooks can fail early with variable not defined error.
-
-#etcd_master_addr:
-#etcd_master_name:

--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -32,10 +32,8 @@
     - "{{ etcd_peer_port1 }}"
     - "{{ etcd_peer_port2 }}"
 
-# The second part of the condition avoids reconfiguring master if it was already present in the host-group
 - name: copy the etcd start/stop script
   template: src=etcd.j2 dest=/usr/bin/etcd.sh mode=u=rwx,g=rx,o=rx
-  when: (etcd_init_cluster == true) or (etcd_init_cluster == false and node_addr != etcd_master_addr)
 
 - name: copy systemd units for etcd
   copy: src=etcd.service dest=/etc/systemd/system/etcd.service

--- a/roles/etcd/templates/etcd.j2
+++ b/roles/etcd/templates/etcd.j2
@@ -51,7 +51,7 @@ export ETCD_INITIAL_CLUSTER_TOKEN=contiv-cluster
 export ETCD_LISTEN_CLIENT_URLS={{ client_url("0.0.0.0") }}
 export ETCD_ADVERTISE_CLIENT_URLS={{ client_url(node_addr) }}
 export ETCD_INITIAL_ADVERTISE_PEER_URLS={{ peer_url(node_addr) }}
-export ETCD_LISTEN_PEER_URLS=http://{{ node_addr }}:{{ etcd_peer_port1 }}
+export ETCD_LISTEN_PEER_URLS=http://0.0.0.0:{{ etcd_peer_port1 }}
 export ETCD_HEARTBEAT_INTERVAL={{ etcd_heartbeat_interval }}
 export ETCD_ELECTION_TIMEOUT={{ etcd_election_timeout }}
 
@@ -62,7 +62,7 @@ export ETCD_ELECTION_TIMEOUT={{ etcd_election_timeout }}
 #  - address of that peer node
 add_proxy() {
     export ETCD_PROXY=on
-    export ETCD_INITIAL_CLUSTER="{{ cluster_url("${1}", "${2}") }}"
+    export ETCD_INITIAL_CLUSTER="{{ cluster_url('cluster_vip', service_vip) }}"
 }
 {% else %}
 # get_peers() returns a comma separated list of peers in 'peers' variable
@@ -127,7 +127,7 @@ add_member() {
 # Else it adds the node to exisitng cluster
 # @args:
 # - none
-init_cluster() {
+init_update_cluster() {
     # on master nodes, if the cluster is being initialized for first time then initialize it
     peers=""
     get_peers "{{ get_peer_addr() }}"
@@ -164,12 +164,9 @@ start)
     fi
     {% if run_as == "worker" -%}
     # on worker nodes, run etcd in proxy mode
-    add_proxy "{{ etcd_master_name }}" "{{ etcd_master_addr }}"
-    {% elif etcd_init_cluster -%}
-    init_cluster
+    add_proxy
     {% else -%}
-    # if a new master node is being commissioned then add it to existing cluster
-    add_member "{{ etcd_master_addr }}"
+    init_update_cluster
     {% endif -%}
 
     #start etcd


### PR DESCRIPTION
- replaced `cluster-init` and `member add` scenarios with just one common handling, this removes the need for explicit `etcd_cluster_init` variable. This was already being tested in cluster-mgr.
- moved etcd-proxy setup logic to use `service_vip`, this removes the need for specifying etcd-master's name and address for configuring a worker nodes.

/cc @vvb @erikh 
