### PR TITLE
Misc fixes

### DIFF
--- a/roles/base/tasks/redhat_tasks.yml
+++ b/roles/base/tasks/redhat_tasks.yml
@@ -17,7 +17,6 @@
     - curl
     - python-requests # XXX required by ceph repo, but it has a bad package on it
     - bash-completion
-    - kernel #keep kernel up to date
     - libselinux-python
     - e2fsprogs
     - openssh-server

--- a/roles/etcd/templates/etcd.j2
+++ b/roles/etcd/templates/etcd.j2
@@ -103,10 +103,10 @@ add_member() {
     res=1
     for i in {1..10}; do
         sleep $[ ( $RANDOM % 10 )  + 1 ]s
-        # XXX: There seems an issue using etcdctl with ETCD_INITIAL_ADVERTISE_PEER_URLS so passing
-        # ETCD_LISTEN_PEER_URLS for now
+        # XXX: There seems an issue using etcdctl with multiple urls set in ETCD_INITIAL_ADVERTISE_PEER_URLS
+        # so setting the single url manually here
         out=`etcdctl {{ etcdctl_flags("${1}") }} \
-            member add {{ node_name }} "$ETCD_LISTEN_PEER_URLS" 2>&1`
+            member add {{ node_name }} "http://{{ node_addr }}:{{ etcd_peer_port1 }}" 2>&1`
         res=$?
         if [ "${res}" == "0" ]; then
             break


### PR DESCRIPTION
- fix the node-address setting in `etcdctl member add` - fixes #244 
  - I am able to verify this in volplugin vagrant setup
- removed updating kernel from base role as it breaks reload of dev vms (https://github.com/contiv/volplugin/issues/332#issuecomment-232223018)
  - I am not able to verify this in volplugin setup (possibly due to: https://github.com/contiv/volplugin/issues/332). @dseevr can you help verify this.

/cc @erikh @dseevr 
