### PR TITLE
fixes missing iptables entries for serf on reboot

### DIFF
--- a/roles/serf/files/serf.service
+++ b/roles/serf/files/serf.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Serf
-After=auditd.service systemd-user-sessions.service time-sync.target
+After=network.target auditd.service systemd-user-sessions.service time-sync.target
 
 [Service]
 ExecStart=/usr/bin/serf.sh start


### PR DESCRIPTION
The Iptables entries for serf are missing on a system reboot. This happens because we apply the rules too soon. This PR will make `iptables` wait until `network` service is up.

```
# iptables rule do not get applied on a reboot - probably because we try and apply them too early
[stack@contiv-b3 ~]$ cat /etc/systemd/system/serf.service | grep After
After=auditd.service systemd-user-sessions.service time-sync.target
[stack@contiv-b3 ~]$
[stack@contiv-b3 ~]$ sudo reboot

# post reboot, the iptables are missing
[stack@contiv-b3 ~]$ sudo iptables -L | grep serf
[stack@contiv-b3 ~]$



# adding a After=network.target sovles this issue
# given that they are needed only after network is up.
[stack@contiv-b3 ~]$ cat /etc/systemd/system/serf.service | grep After
After=network.target auditd.service systemd-user-sessions.service time-sync.target
[stack@contiv-b3 ~]$

# reboot
[stack@contiv-b3 ~]$ sudo reboot

# Login and check iptables
[stack@contiv-b3 ~]$ sudo iptables -L | grep serf
ACCEPT     tcp  --  anywhere             anywhere             tcp dpt:7946 /* serf control */
ACCEPT     udp  --  anywhere             anywhere             udp dpt:mdns /* serf discovery dport */
ACCEPT     udp  --  anywhere             anywhere             udp spt:mdns /* serf discovery sport */
[stack@contiv-b3 ~]$
```
