### PR TITLE
Ubuntu1604 (Xenial) support

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,42 +23,57 @@ ansible_tags =  ENV["CONTIV_ANSIBLE_TAGS"] || "prebake-for-dev"
 ansible_extra_vars = {
     "env" => host_env,
     "validate_certs" => "no",
+    "control_interface" => "eth1",
 }
 
 puts "Host environment: #{host_env}"
 
 Vagrant.configure(2) do |config|
-    node_name = "host0"
-    config.vm.define node_name do |node|
-        node.vm.hostname = node_name
-        node.vm.box = "puppetlabs/centos-7.2-64-nocm"
-        node.vm.box_version = "1.0.1"
-        node.vm.provision "shell" do |s|
-            #XXX: seems like the centos box has a broken packer binary which
-            #get's stuck on issuing 'packer --version' removing it manually here
-            s.inline = "rm -f /usr/sbin/packer"
-        end
+    (0..1).each do |n|
+        node_name = "host#{n}"
+        config.vm.define node_name do |node|
+            node.vm.hostname = node_name
+            if n == 0 then
+                node.vm.box = "puppetlabs/centos-7.2-64-nocm"
+                node.vm.box_version = "1.0.1"
+                node.vm.provision "shell" do |s|
+                    #XXX: seems like the centos box has a broken packer binary which
+                    #get's stuck on issuing 'packer --version' removing it manually here
+                    s.inline = "rm -f /usr/sbin/packer"
+                end
+            else
+                node.vm.box = "ubuntu/xenial64"
+                node.vm.box_version = "20160420.3.0"
+                node.vm.provision "shell" do |s|
+                    #XXX: Ubuntu 16.04 /etc/hosts is not creating entry for hostname,
+                    #so create it here
+                    s.inline = "echo 127.0.1.1 ubuntu-xenial >> /etc/hosts"
+                end
+            end
 
-        # set the vm's ram and cpu big enough for docker to run fine
-        node.vm.provider "virtualbox" do |vb|
-            vb.customize ['modifyvm', :id, '--memory', "4096"]
-            vb.customize ["modifyvm", :id, "--cpus", "2"]
-            vb.customize ['modifyvm', :id, '--paravirtprovider', 'kvm']
-            vb.customize ['modifyvm', :id, '--natdnshostresolver1', 'on']
-            vb.customize ['modifyvm', :id, '--natdnsproxy1', 'on']
-            vb.linked_clone = true if Vagrant::VERSION =~ /^1.8/
-        end
+            node.vm.provider "virtualbox" do |vb|
+                vb.customize ['modifyvm', :id, '--memory', "4096"]
+                vb.customize ["modifyvm", :id, "--cpus", "2"]
+                vb.customize ['modifyvm', :id, '--paravirtprovider', 'kvm']
+                vb.customize ['modifyvm', :id, '--natdnshostresolver1', 'on']
+                vb.customize ['modifyvm', :id, '--natdnsproxy1', 'on']
+                vb.linked_clone = true if Vagrant::VERSION =~ /^1.8/
+            end
 
-        if ansible_groups["devtest"] == nil then
-            ansible_groups["devtest"] = [ ]
-        end
-        ansible_groups["devtest"] << node_name
-        node.vm.provision 'ansible' do |ansible|
-            ansible.groups = ansible_groups
-            ansible.playbook = ansible_playbook
-            ansible.extra_vars = ansible_extra_vars
-            ansible.limit = 'all'
-            ansible.tags = ansible_tags
+            if ansible_groups["devtest"] == nil then
+                ansible_groups["devtest"] = [ ]
+            end
+            ansible_groups["devtest"] << node_name
+            # Run the provisioner after all machines are up
+            if n == 1 then
+                node.vm.provision 'ansible' do |ansible|
+                    ansible.groups = ansible_groups
+                    ansible.playbook = ansible_playbook
+                    ansible.extra_vars = ansible_extra_vars
+                    ansible.limit = 'all'
+                    ansible.tags = ansible_tags
+                end
+            end
         end
     end
 end

--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -8,3 +8,6 @@ docker_rule_comment: "docker api"
 docker_device: ""
 docker_device_size: "10000MB"
 docker_device_metadata_size: "1000MB"
+docker_cs_engine_supported_versions_ubuntu:
+    "wily": [ "1.10", "1.11" ]
+    "xenial": [ "1.11" ]

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -9,16 +9,6 @@
   tags:
     - prebake-for-dev
 
-- include: ubuntu_install_tasks.yml
-  when: (ansible_os_family == "Debian") and not (docker_installed_version.stdout | match("Docker version {{ docker_version }}, build.*"))
-  tags:
-    - prebake-for-dev
-
-- include: redhat_install_tasks.yml
-  when: (ansible_os_family == "RedHat") and not (docker_installed_version.stdout | match("Docker version {{ docker_version }}, build.*"))
-  tags:
-    - prebake-for-dev
-
 - name: create docker daemon's config directory
   file: path=/etc/systemd/system/docker.service.d state=directory
   tags:
@@ -26,6 +16,16 @@
 
 - name: setup docker daemon's environment
   template: src=env.conf.j2 dest=/etc/systemd/system/docker.service.d/env.conf
+  tags:
+    - prebake-for-dev
+
+- include: ubuntu_install_tasks.yml
+  when: (ansible_os_family == "Debian") and not (docker_installed_version.stdout | match("Docker version {{ docker_version }}, build.*"))
+  tags:
+    - prebake-for-dev
+
+- include: redhat_install_tasks.yml
+  when: (ansible_os_family == "RedHat") and not (docker_installed_version.stdout | match("Docker version {{ docker_version }}, build.*"))
   tags:
     - prebake-for-dev
 

--- a/roles/docker/tasks/ubuntu_install_tasks.yml
+++ b/roles/docker/tasks/ubuntu_install_tasks.yml
@@ -12,9 +12,7 @@
   apt_repository:
     repo: "deb https://packages.docker.com/{{ item }}/apt/repo ubuntu-{{ ansible_distribution_release }} main"
     state: present
-  with_items:
-    - "1.10"
-    - "1.11"
+  with_items: "{{ docker_cs_engine_supported_versions_ubuntu[ansible_distribution_release] }}"
 
 - name: install docker (debian)
   shell: curl https://get.docker.com | sed 's/docker-engine/--force-yes docker-engine={{ docker_version }}-0~{{ ansible_distribution_release }}/' | bash


### PR DESCRIPTION
This PR brings in the changes required to support Ubuntu 1604 in ansible.

The change is mostly in Vagrantfile to enable the CI with Ubuntu 15.10 and 16.04 flavors.

There are no major functional changes except for:
- handling docker CS engine repos as Docker CS engine support for Xenial seems to be only from version 1.11 onwards.
- moving environment file setup for docker daemon ahead of  installation task. This ensures that docker service get's started with updated environment.

/cc @contiv/core-storage @contiv/core-network @vvb 
