### PR TITLE
roles/test: add task to start virtualbox as a daemon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,3 +8,6 @@ test-provision:
 
 test-cleanup:
 	CONTIV_ANSIBLE_PLAYBOOK="./cleanup.yml" CONTIV_ANSIBLE_TAGS="all" vagrant provision
+
+test-test:
+	CONTIV_ANSIBLE_TAGS="prebake-for-test" vagrant provision

--- a/roles/test/files/vbox.service
+++ b/roles/test/files/vbox.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Virtualbox Server
+After=network.target auditd.service systemd-user-sessions.service time-sync.target
+
+[Service]
+ExecStart=/usr/lib/virtualbox/VBoxSVC --pidfile VBoxSVC.pid
+Restart=on-failure
+RestartSec=10
+KillMode=control-group
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/test/tasks/redhat_tasks.yml
+++ b/roles/test/tasks/redhat_tasks.yml
@@ -22,6 +22,12 @@
     - kernel-devel
     - dkms
 
+- name: copy systemd units for virtualbox-server
+  copy: src=vbox.service dest=/etc/systemd/system/vbox.service
+
+- name: enable vbox to be started on boot-up and start it as well
+  service: name=vbox state=started enabled=yes
+
 - name: download vagrant (redhat)
   get_url:
     validate_certs: "{{ validate_certs }}"

--- a/roles/test/tasks/ubuntu_tasks.yml
+++ b/roles/test/tasks/ubuntu_tasks.yml
@@ -11,6 +11,12 @@
 - name: install VBox dkms (debian)
   apt: name=dkms state=latest
 
+- name: copy systemd units for virtualbox-server
+  copy: src=vbox.service dest=/etc/systemd/system/vbox.service
+
+- name: enable vbox to be started on boot-up and start it as well
+  service: name=vbox state=started enabled=yes
+
 - name: download vagrant (debian)
   get_url:
     validate_certs: "{{ validate_certs }}"


### PR DESCRIPTION
this is required for CI environment with parallel builds to ensure that the vagrant setups in other CI tasks are not aborted when one CI task completes.

more details are here: https://github.com/mitchellh/vagrant/issues/6228
