### PR TITLE
roles/test: set the user in vbox service

### DIFF
--- a/roles/test/tasks/redhat_tasks.yml
+++ b/roles/test/tasks/redhat_tasks.yml
@@ -23,7 +23,7 @@
     - dkms
 
 - name: copy systemd units for virtualbox-server
-  copy: src=vbox.service dest=/etc/systemd/system/vbox.service
+  template: src=vbox.service.j2 dest=/etc/systemd/system/vbox.service
 
 - name: enable vbox to be started on boot-up and start it as well
   service: name=vbox state=started enabled=yes

--- a/roles/test/tasks/ubuntu_tasks.yml
+++ b/roles/test/tasks/ubuntu_tasks.yml
@@ -12,7 +12,7 @@
   apt: name=dkms state=latest
 
 - name: copy systemd units for virtualbox-server
-  copy: src=vbox.service dest=/etc/systemd/system/vbox.service
+  template: src=vbox.service.j2 dest=/etc/systemd/system/vbox.service
 
 - name: enable vbox to be started on boot-up and start it as well
   service: name=vbox state=started enabled=yes

--- a/roles/test/templates/vbox.service.j2
+++ b/roles/test/templates/vbox.service.j2
@@ -7,6 +7,7 @@ ExecStart=/usr/lib/virtualbox/VBoxSVC --pidfile VBoxSVC.pid
 Restart=on-failure
 RestartSec=10
 KillMode=control-group
+User={{ ansible_user }}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
By default service is started as root and the vbox service only seems to listen for requests coming from user running the vm.

This ensures that the vbox server receives the request from jenkins.
