### PR TITLE
roles/ceph-mon/tasks/secure_cluster.yml: use variable interpolation which is compatible with Ansible 2.1

### DIFF
--- a/roles/ceph-mon/tasks/secure_cluster.yml
+++ b/roles/ceph-mon/tasks/secure_cluster.yml
@@ -7,6 +7,6 @@
 - name: secure the cluster
   command: ceph osd pool set {{ item[0] }} {{ item[1] }} true
   with_nested:
-    - ceph_pools.stdout_lines
+    - "{{ ceph_pools.stdout_lines }}"
     - secure_cluster_flags
   when: "{{ ceph_version.stdout | version_compare('0.94', '>=') }}"


### PR DESCRIPTION
The "secure the cluster" task is currently failing on Ansible 2.1 (tested with 2.1.1.0).  Here's the error:

```
TASK [ceph-mon : secure the cluster] *******************************************
Thursday 11 August 2016  18:14:33 -0700 (0:00:00.106)       0:04:21.808 *******
[DEPRECATION WARNING]: Using bare variables is deprecated. Update your
playbooks so that the environment value uses the full variable syntax
('{{ceph_pools.stdout_lines}}').
This feature will be removed in a future
release. Deprecation warnings can be disabled by setting
deprecation_warnings=False in ansible.cfg.
fatal: [mon0]: FAILED! => {"failed": true, "msg": "'dict object' has no attribute 'stdout_lines'"}
```

This PR is a backwards-compatible fix (tested and working with 2.0.0.2).

Signed-off-by: Bill Robinson dseevr@users.noreply.github.com
