### PR TITLE
Misc fixes and enhancements

### DIFF
--- a/cleanup.yml
+++ b/cleanup.yml
@@ -15,15 +15,34 @@
         - "ucp"
         - "docker"
         - "etcd"
-    - include: roles/{{ item }}/tasks/cleanup.yml
-      with_items:
-        - ucarp
-        - contiv_network
-        - contiv_storage
-        - swarm
-        - kubernetes
-        - ucp
-        - etcd
-        - nfs
-        - docker
+    - include: roles/ucarp/tasks/cleanup.yml
       ignore_errors: yes
+    - include: roles/contiv_network/tasks/cleanup.yml
+      ignore_errors: yes
+    - include: roles/contiv_storage/tasks/cleanup.yml
+      ignore_errors: yes
+    - include: roles/swarm/tasks/cleanup.yml
+      ignore_errors: yes
+    - include: roles/kubernetes/tasks/cleanup.yml
+      ignore_errors: yes
+    - include: roles/ucp/tasks/cleanup.yml
+      ignore_errors: yes
+    - include: roles/etcd/tasks/cleanup.yml
+      ignore_errors: yes
+    - include: roles/nfs/tasks/cleanup.yml
+      ignore_errors: yes
+    - include: roles/docker/tasks/cleanup.yml
+      ignore_errors: yes
+# XXX: the following doesn't work with ansible 2.1.1 (https://github.com/ansible/ansible/issues/17144)
+#    - include: roles/{{ item }}/tasks/cleanup.yml
+#      with_items:
+#        - ucarp
+#        - contiv_network
+#        - contiv_storage
+#        - swarm
+#        - kubernetes
+#        - ucp
+#        - etcd
+#        - nfs
+#        - docker
+#      ignore_errors: yes

--- a/roles/contiv_network/tasks/ovs_cleanup.yml
+++ b/roles/contiv_network/tasks/ovs_cleanup.yml
@@ -1,17 +1,11 @@
 ---
 # This play contains tasks for cleaning up contiv_network services
 
-# XXX: looks like for ansible 1.9 ignore_errors is not propogated to nested includes
-# so we need to be set it per task here eventhough it is specified at the top level
-# include task. Remove this once we have moved to ansible v2
-
 - name: cleanup ovs vlan state
   shell: ovs-vsctl del-br contivVlanBridge
-  ignore_errors: yes
 
 - name: cleanup ovs vxlan state
   shell: ovs-vsctl del-br contivVxlanBridge
-  ignore_errors: yes
 
 - name: cleanup ports
   shell: >
@@ -20,7 +14,6 @@
       done
   args:
     executable: /bin/bash
-  ignore_errors: yes
   register: ports
 
 - debug: var=ports


### PR DESCRIPTION
- fix the cleanup tasks by expanding the loop of includes. Looks like this is might be broken in latest  ansible, so filed an issue there as well: https://github.com/ansible/ansible/issues/17144
- cleaned up some extra ignore_errors fields, that are not needed anymore with ansible 2.0 +

fixes #264 
