### PR TITLE
Add clear container runtime to docker

### DIFF
--- a/roles/docker/templates/docker-svc.j2
+++ b/roles/docker/templates/docker-svc.j2
@@ -8,9 +8,9 @@ Requires=docker.socket
 TimeoutStartSec=5m
 Type=notify
 {% if docker_device != "" %}
-ExecStart=/usr/bin/docker daemon --storage-opt dm.thinpooldev=/dev/mapper/contiv-dockerthin -H fd:// --cluster-store=etcd://localhost:{{ etcd_client_port1 }}
+ExecStart=/usr/bin/docker daemon --storage-opt dm.thinpooldev=/dev/mapper/contiv-dockerthin -H fd:// --cluster-store=etcd://localhost:{{ etcd_client_port1 }} --add-runtime cor=/usr/bin/cc-oci-runtime --default-runtime=runc
 {% else %}
-ExecStart=/usr/bin/docker daemon -H fd:// --cluster-store=etcd://localhost:{{ etcd_client_port1 }}
+ExecStart=/usr/bin/docker daemon -H fd:// --cluster-store=etcd://localhost:{{ etcd_client_port1 }} --add-runtime cor=/usr/bin/cc-oci-runtime --default-runtime=runc
 {% endif %}
 MountFlags={{ docker_mount_flags }}
 LimitNOFILE=1048576


### PR DESCRIPTION
Add clear containers as an additional runtime. The default runtime
is still runc. Explicitly use --runtime=cor at the time of workload
container launch to use clear container based isolation.

Signed-off-by: Manohar Castelino manohar.r.castelino@intel.com
