### PR TITLE
aws.tf,.gitignore: Terraform AWS environment to run netplugin!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ fetch/*
 
 #vagrant temp files
 .vagrant*
+
+terraform.tfstate*

--- a/aws.tf
+++ b/aws.tf
@@ -1,0 +1,180 @@
+provider "aws" {
+  region = "${var.aws_region}"
+}
+
+variable "nodes" {
+  default = 3
+}
+
+variable "ami" {
+  default = "ami-af4333cf"
+}
+
+variable "aws_key_name" {
+  description = "The name of your SSH key on AWS"
+  type        = "string"
+}
+
+variable "rerun" {
+  type    = "string"
+  default = ""
+}
+
+variable "aws_region" {
+  default = "us-west-1"
+}
+
+variable "instance_class" {
+  default = "c3.large"
+}
+
+resource "aws_vpc" "netplugin-testvpc" {
+  cidr_block           = "10.1.0.0/16"
+  enable_dns_hostnames = true
+}
+
+resource "aws_internet_gateway" "netplugin-gw" {
+  vpc_id = "${aws_vpc.netplugin-testvpc.id}"
+}
+
+resource "aws_route_table" "netplugin-rt" {
+  vpc_id = "${aws_vpc.netplugin-testvpc.id}"
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = "${aws_internet_gateway.netplugin-gw.id}"
+  }
+}
+
+resource "aws_route_table_association" "netplugin-rta" {
+  subnet_id      = "${aws_subnet.netplugin-main-subnet.id}"
+  route_table_id = "${aws_route_table.netplugin-rt.id}"
+}
+
+resource "aws_subnet" "netplugin-main-subnet" {
+  vpc_id     = "${aws_vpc.netplugin-testvpc.id}"
+  cidr_block = "10.1.0.0/24"
+}
+
+resource "aws_subnet" "netplugin-control-subnet" {
+  vpc_id            = "${aws_vpc.netplugin-testvpc.id}"
+  cidr_block        = "10.1.10.0/24"
+  availability_zone = "${aws_subnet.netplugin-main-subnet.availability_zone}"
+}
+
+resource "aws_subnet" "netplugin-vlan-subnet" {
+  vpc_id            = "${aws_vpc.netplugin-testvpc.id}"
+  cidr_block        = "10.1.20.0/24"
+  availability_zone = "${aws_subnet.netplugin-main-subnet.availability_zone}"
+}
+
+resource "aws_security_group" "netplugin-sg" {
+  vpc_id = "${aws_vpc.netplugin-testvpc.id}"
+
+  ingress {
+    protocol    = "tcp"
+    from_port   = 22
+    to_port     = 22
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    protocol    = "icmp"
+    from_port   = 8
+    to_port     = 8
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    protocol    = "-1"
+    from_port   = 0
+    to_port     = 0
+    self        = true
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    protocol  = "-1"
+    from_port = 0
+    to_port   = 0
+    self      = true
+  }
+}
+
+resource "aws_eip" "netplugin-eip" {
+  vpc      = true
+  instance = "${element(aws_instance.netplugin-node.*.id, count.index)}"
+  count    = "${var.nodes}"
+}
+
+resource "aws_network_interface" "netplugin-control-if" {
+  subnet_id       = "${aws_subnet.netplugin-control-subnet.id}"
+  security_groups = ["${aws_security_group.netplugin-sg.id}"]
+  private_ips     = ["10.1.10.1${count.index}"]
+  count           = "${var.nodes}"
+
+  attachment {
+    instance     = "${element(aws_instance.netplugin-node.*.id, count.index)}"
+    device_index = 1
+  }
+
+  depends_on = ["aws_instance.netplugin-node", "aws_eip.netplugin-eip"]
+}
+
+resource "aws_network_interface" "netplugin-vlan-if" {
+  subnet_id       = "${aws_subnet.netplugin-vlan-subnet.id}"
+  security_groups = ["${aws_security_group.netplugin-sg.id}"]
+  private_ips     = ["10.1.20.1${count.index}"]
+  count           = "${var.nodes}"
+
+  attachment {
+    instance     = "${element(aws_instance.netplugin-node.*.id, count.index)}"
+    device_index = 2
+  }
+
+  depends_on = ["aws_network_interface.netplugin-control-if"]
+}
+
+resource "aws_instance" "netplugin-node" {
+  ami                    = "${var.ami}"
+  instance_type          = "${var.instance_class}"
+  key_name               = "${var.aws_key_name}"
+  subnet_id              = "${aws_subnet.netplugin-main-subnet.id}"
+  count                  = "${var.nodes}"
+  availability_zone      = "${aws_subnet.netplugin-main-subnet.availability_zone}"
+  vpc_security_group_ids = ["${aws_security_group.netplugin-sg.id}"]
+}
+
+resource "null_resource" "configure-interfaces" {
+  count = "${var.nodes}"
+
+  provisioner "remote-exec" {
+    inline = ["sudo /sbin/ip addr add '10.1.10.1${count.index}/24' dev eth1 && sudo /sbin/ip link set dev eth1 up"]
+  }
+
+  connection {
+    user = "centos"
+    host = "${element(aws_eip.netplugin-eip.*.public_ip, count.index)}"
+  }
+
+  depends_on = ["aws_network_interface.netplugin-control-if"]
+}
+
+resource "null_resource" "ansible" {
+  provisioner "local-exec" {
+    command = "echo '
+            [service-master]
+            ${aws_eip.netplugin-eip.0.public_ip}
+            [service-worker]
+            ${join("\n", aws_eip.netplugin-eip.*.public_ip)}
+            ' >/tmp/hosts && \\
+            ansible-playbook -e '{ \"netplugin_if\": \"eth2\", \"netmaster_ip\": \"10.1.10.10\", \"control_interface\": \"eth1\", \"env\": {} }' -i /tmp/hosts --ssh-extra-args='-o StrictHostKeyChecking=false' -T 300 -u centos site.yml"
+  }
+
+  triggers {
+    rerun                = "${rerun}"
+    cluster_instance_ids = "${join(",", aws_instance.netplugin-node.*.id)}"
+  }
+
+  depends_on = ["null_resource.configure-interfaces"]
+}

--- a/group_vars/all
+++ b/group_vars/all
@@ -16,14 +16,17 @@ ceph_stable_ice_kmod: ""
 #host variables
 node_name: "{{ inventory_hostname }}"
 node_addr: "{{ hostvars[inventory_hostname]['ansible_' + control_interface]['ipv4']['address'] }}"
-
 validate_certs: "yes"
+service_vip: "{{ netmaster_ip }}"
 
 # following variables are used in one or more roles, but have no good default value to pick from.
 # Leaving them as commented so that playbooks can fail early due to variable not defined error.
 
 # env:
-# service_vip:
 # control_interface:
+
+## the comparison this way allows us to override ucarp when netmaster_ip is
+## non-nil. If it is nil, service_ip should be set to something unique.
+# netmaster_ip:
 
 host_capability: "can-run-user-containers, storage"

--- a/roles/dev/meta/main.yml
+++ b/roles/dev/meta/main.yml
@@ -17,6 +17,4 @@ dependencies:
 - { role: etcd }
 - { role: swarm }
 - { role: ucp }
-- { role: contiv_cluster }
 - { role: contiv_network }
-- { role: contiv_storage }

--- a/roles/dev/meta/main.yml
+++ b/roles/dev/meta/main.yml
@@ -12,7 +12,6 @@
 # 'prebake-for-dev' tag in respective roles.
 
 dependencies:
-- { role: ceph-install, tags: 'prebake-for-dev' }
 - { role: ansible, tags: 'prebake-for-dev' }
 - { role: docker }
 - { role: etcd }

--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -11,4 +11,5 @@ docker_device_metadata_size: "1000MB"
 docker_cs_engine_supported_versions_ubuntu:
     "wily": [ "1.10", "1.11" ]
     "xenial": [ "1.11" ]
+    "Core": [""] # needed for redhat installations due to templating
 docker_mount_flags: "shared"

--- a/roles/ucarp/tasks/install_ucarp.yml
+++ b/roles/ucarp/tasks/install_ucarp.yml
@@ -1,0 +1,22 @@
+---
+# This role contains tasks for configuring and starting ucarp service
+
+- name: download and install ucarp service (Redhat)
+  yum: name=ucarp state=present
+  when: ansible_os_family == "RedHat"
+
+- name: download and install ucarp service (Ubuntu)
+  apt: name=ucarp state=present
+  when: ansible_os_family == "Debian"
+
+- name: copy the ucarp start/stop script
+  template: src=ucarp.sh.j2 dest=/usr/bin/ucarp.sh mode=u=rwx,g=rx,o=rx
+
+- name: copy the vip up and down scripts used by ucarp
+  copy: src=ucarp/ dest=/usr/bin/ucarp/ mode=u=rwx,g=rx,o=rx
+
+- name: copy systemd units for ucarp
+  copy: src=ucarp.service dest=/etc/systemd/system/ucarp.service
+
+- name: start ucarp
+  service: name=ucarp state=started

--- a/roles/ucarp/tasks/main.yml
+++ b/roles/ucarp/tasks/main.yml
@@ -1,22 +1,7 @@
 ---
-# This role contains tasks for configuring and starting ucarp service
 
-- name: download and install ucarp service (Redhat)
-  yum: name=ucarp state=present
-  when: ansible_os_family == "RedHat"
-
-- name: download and install ucarp service (Ubuntu)
-  apt: name=ucarp state=present
-  when: ansible_os_family == "Debian"
-
-- name: copy the ucarp start/stop script
-  template: src=ucarp.sh.j2 dest=/usr/bin/ucarp.sh mode=u=rwx,g=rx,o=rx
-
-- name: copy the vip up and down scripts used by ucarp
-  copy: src=ucarp/ dest=/usr/bin/ucarp/ mode=u=rwx,g=rx,o=rx
-
-- name: copy systemd units for ucarp
-  copy: src=ucarp.service dest=/etc/systemd/system/ucarp.service
-
-- name: start ucarp
-  service: name=ucarp state=started
+## the comparison this way allows us to override ucarp when netmaster_ip is
+## non-nil. If it is nil, service_ip should be set to something unique.
+- name: install ucarp
+  include: install_ucarp.yml
+  when: netmaster_ip is undefined

--- a/site.yml
+++ b/site.yml
@@ -69,7 +69,6 @@
   # - { role: ceph-osd, mon_group_name: service-master, osd_group_name: service-master, when: host_capability|match('.*storage.*') }
   - { role: scheduler_stack, run_as: master, when: host_capability|match('.*can-run-user-containers.*') }
   - { role: contiv_network, run_as: master, when: host_capability|match('.*can-run-user-containers.*') }
-  - { role: contiv_storage, run_as: master }
 
 # service-worker hosts correspond to cluster machines that run the worker/driver
 # logic of the infra services.
@@ -84,7 +83,6 @@
   # - { role: ceph-osd, mon_group_name: service-master, osd_group_name: service-worker, when: host_capability|match('.*storage.*') }
   - { role: scheduler_stack, run_as: worker, when: host_capability|match('.*can-run-user-containers.*') }
   - { role: contiv_network, run_as: worker, when: host_capability|match('.*can-run-user-containers.*') }
-  - { role: contiv_storage, run_as: worker }
 
 # netplugin-node hosts set up netmast/netplugin in a cluster
 - hosts: netplugin-node


### PR DESCRIPTION
This supplies an `aws.tf` at hte root of the tree that provisions the ansible to N hosts (3 by default) in AWS.

It can be run by configuring your AWS shell environment, checking out this branch, installing [terraform](terraform.io) and typing:

```
$ terraform apply .
```

When you are ready to destroy it:

```
$ terraform destroy .
```

To get the IP addresses of the hosts (and a lot of other info):

```
$ terraform show
```

**the terraform.tfstate file is very important to keep! do NOT delete it!**

This will provision all the resources on AWS it needs and open ssh to the world with the key information you provide when asked (you can also supply this on the commandline if you find it annoying). It will then run an ansible plan against the hosts to install netmaster on the first host and netplugin's stack on all of them.

This isn't as pretty as I'd like, but it's working well in practice so far. I'm not super sure if the vlan support actually works on AWS, I didn't test. However, overlay networking operates as expected.

The ansible was modified to remove many volplugin requirements that lived in the netplugin namespace, these can be re-added at a later time if desired.

Please try this branch before reviewing it, unless you are very comfortable speaking terraform. It's a complicated system that's hard to understand at first.