### PR TITLE
add dynamic loading to include modules

### DIFF
--- a/cleanup.yml
+++ b/cleanup.yml
@@ -15,34 +15,16 @@
         - "ucp"
         - "docker"
         - "etcd"
-    - include: roles/ucarp/tasks/cleanup.yml
+    - include: roles/{{ item }}/tasks/cleanup.yml
+      with_items:
+        - ucarp
+        - contiv_network
+        - contiv_storage
+        - swarm
+        - kubernetes
+        - ucp
+        - etcd
+        - nfs
+        - docker
+      static: no
       ignore_errors: yes
-    - include: roles/contiv_network/tasks/cleanup.yml
-      ignore_errors: yes
-    - include: roles/contiv_storage/tasks/cleanup.yml
-      ignore_errors: yes
-    - include: roles/swarm/tasks/cleanup.yml
-      ignore_errors: yes
-    - include: roles/kubernetes/tasks/cleanup.yml
-      ignore_errors: yes
-    - include: roles/ucp/tasks/cleanup.yml
-      ignore_errors: yes
-    - include: roles/etcd/tasks/cleanup.yml
-      ignore_errors: yes
-    - include: roles/nfs/tasks/cleanup.yml
-      ignore_errors: yes
-    - include: roles/docker/tasks/cleanup.yml
-      ignore_errors: yes
-# XXX: the following doesn't work with ansible 2.1.1 (https://github.com/ansible/ansible/issues/17144)
-#    - include: roles/{{ item }}/tasks/cleanup.yml
-#      with_items:
-#        - ucarp
-#        - contiv_network
-#        - contiv_storage
-#        - swarm
-#        - kubernetes
-#        - ucp
-#        - etcd
-#        - nfs
-#        - docker
-#      ignore_errors: yes

--- a/roles/contiv_network/tasks/cleanup.yml
+++ b/roles/contiv_network/tasks/cleanup.yml
@@ -29,3 +29,5 @@
     - "{{ bgp_port }}"
 
 - include: ovs_cleanup.yml
+  static: no
+  ignore_errors: yes


### PR DESCRIPTION
Add dynamic loading of include modules. The behavior of include modules changed in Ansible 2.1.
Include ignore_errors for ovs_cleanup tasks.