### PR TITLE
roles/contiv_network/tasks: remove skydns

### DIFF
--- a/roles/contiv_network/tasks/main.yml
+++ b/roles/contiv_network/tasks/main.yml
@@ -1,17 +1,5 @@
 ---
 # This role contains tasks for configuring and starting netmaster and netplugin service
-- name: check dns container image
-  shell: docker inspect skynetservices/skydns
-  register: docker_inspect_result
-  ignore_errors: yes
-  tags:
-    - prebake-for-dev
-
-- name: pull dns container image
-  shell: docker pull skynetservices/skydns
-  when: "'No such image' in docker_inspect_result.stderr"
-  tags:
-    - prebake-for-dev
 
 # install ovs, needed for our netplugin deployments. In future, if needed, this
 # install can be conditional based on deployment environment.


### PR DESCRIPTION
This removes skydns because it's not needed any more.

Fixes #286