### PR TITLE
os_agnostic_tasks: bump Go to 1.7.4

### DIFF
--- a/roles/dev/tasks/os_agnostic_tasks.yml
+++ b/roles/dev/tasks/os_agnostic_tasks.yml
@@ -1,6 +1,6 @@
 - name: Set Go version
   set_fact:
-    go_version: "1.7"
+    go_version: "1.7.4"
 
 - name: "download Golang {{ go_version }}"
   get_url:


### PR DESCRIPTION
This bumps Go to 1.7.4. This includes security and bug fixes.