### PR TITLE
Adding cluster_store vars for netmaster & netplugin

### DIFF
--- a/roles/contiv_network/defaults/main.yml
+++ b/roles/contiv_network/defaults/main.yml
@@ -7,6 +7,9 @@
 contiv_network_mode: "standalone" # Accepted values: standalone, aci
 netplugin_mode: "docker" # Accepted values: docker, kubernetes
 fwd_mode: "bridge" #Accepted values: bridge , routing
+
+cluster_store: "etcd://127.0.0.1:2379"
+
 ofnet_master_port: 9001
 ofnet_agent_port1: 9002
 ofnet_agent_port2: 9003

--- a/roles/contiv_network/templates/netmaster.j2
+++ b/roles/contiv_network/templates/netmaster.j2
@@ -1,1 +1,1 @@
-NETMASTER_ARGS="--cluster-mode {{netplugin_mode}}"
+NETMASTER_ARGS="--cluster-mode {{netplugin_mode}} -cluster-store {{cluster_store}} "

--- a/roles/contiv_network/templates/netplugin.j2
+++ b/roles/contiv_network/templates/netplugin.j2
@@ -1,1 +1,1 @@
-NETPLUGIN_ARGS='-plugin-mode {{netplugin_mode}} -vlan-if {{netplugin_if}} -vtep-ip {{node_addr}} -ctrl-ip {{node_addr}} '
+NETPLUGIN_ARGS='-plugin-mode {{netplugin_mode}} -vlan-if {{netplugin_if}} -vtep-ip {{node_addr}} -ctrl-ip {{node_addr}} -cluster-store {{cluster_store}} '


### PR DESCRIPTION
This is required for separating the etcd cluster from contiv_network installation.