### PR TITLE
Add status logs for etcd & netmaster to aid debugging

### DIFF
--- a/roles/contiv_network/tasks/main.yml
+++ b/roles/contiv_network/tasks/main.yml
@@ -107,6 +107,24 @@
   retries: 9
   delay: 10
 
+# get the netmaster status for debugging in case there are errors
+- name: get netmaster status
+  shell: systemctl status netmaster -l
+  register: netmaster_status
+  when: (run_as == "master")
+
+- debug: msg={{ netmaster_status.stdout }} verbosity=2
+  when: (run_as == "master")
+  ignore_errors: true
+
+# get the netplugin status for debugging in case there are errors
+- name: get netplugin status
+  shell: systemctl status netplugin -l
+  register: netplugin_status
+
+- debug: msg={{ netplugin_status.stdout }} verbosity=2
+  ignore_errors: true
+
 - include: aci_tasks.yml
   when: (run_as == "master") and (contiv_network_mode == "aci")
 

--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -41,4 +41,13 @@
 - name: start etcd
   service: name=etcd state=started
 
+- name: wait for etcd to startup
+  shell: systemctl status etcd -l
+  register: etcd_result
+  until: etcd_result.stdout.find("Active") != -1
+  retries: 9
+  delay: 10
+
+- debug: msg={{ etcd_result.stdout }} verbosity=2
+  ignore_errors: true
 


### PR DESCRIPTION
We are frequently seeing installs fail with netmaster not starting.
Adding logs to make debugging such cases simpler.