### PR TITLE
docker: bump Docker to 1.12.6 & compose to 1.10

### DIFF
--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -2,8 +2,8 @@
 # Default values for docker role
 
 docker_api_port: 2385
-docker_version: 1.11.1
-docker_compose_version: 1.8.0-rc1
+docker_version: 1.12.6
+docker_compose_version: 1.10.0
 docker_rule_comment: "docker api"
 docker_device: ""
 docker_device_size: "10000MB"


### PR DESCRIPTION
This PR bumps Docker to version 1.12.6 and Docker compose to 1.10.

Different versions of Docker can still be installed.