### PR TITLE
roles/dev/tasks/os_agnostic: bump Go to 1.7.5

### DIFF
--- a/roles/dev/tasks/os_agnostic_tasks.yml
+++ b/roles/dev/tasks/os_agnostic_tasks.yml
@@ -1,6 +1,6 @@
 - name: Set Go version
   set_fact:
-    go_version: "1.7.4"
+    go_version: "1.7.5"
 
 - name: "download Golang {{ go_version }}"
   get_url:


### PR DESCRIPTION
This bumps Go to 1.7.5.

The changelog can be found here: https://github.com/golang/go/issues?q=milestone%3AGo1.7.5