### PR TITLE
Adding auth_proxy role and install files

### DIFF
--- a/install_auth_proxy.yml
+++ b/install_auth_proxy.yml
@@ -1,0 +1,5 @@
+# netplugin-master hosts set up the proxy
+- hosts: netplugin-master
+  become: true
+  roles:
+    - { role: auth_proxy }

--- a/install_base.yml
+++ b/install_base.yml
@@ -1,0 +1,6 @@
+# netplugin-node hosts set up netmast/netplugin in a cluster
+- hosts: netplugin-node
+  become: true
+  environment: '{{ env }}'
+  roles:
+  - { role: base }

--- a/install_contiv.yml
+++ b/install_contiv.yml
@@ -1,0 +1,11 @@
+# netplugin-master hosts set up netmaster and rest as netplugin
+- hosts: netplugin-master
+  become: true
+  environment: '{{ env }}'
+  roles:
+    - { role: contiv_network, scheduler_provider: native-swarm, run_as: master }
+- hosts: netplugin-worker
+  become: true
+  environment: '{{ env }}'
+  roles:
+    - { role: contiv_network, scheduler_provider: native-swarm, run_as: worker }

--- a/install_docker.yml
+++ b/install_docker.yml
@@ -1,0 +1,6 @@
+# netplugin-node hosts set up netmast/netplugin in a cluster
+- hosts: netplugin-node
+  become: true
+  environment: '{{ env }}'
+  roles:
+  - { role: docker, etcd_client_port1: 2379 }

--- a/install_etcd.yml
+++ b/install_etcd.yml
@@ -1,0 +1,12 @@
+# netplugin-master hosts set up netmaster nodes
+- hosts: netplugin-master
+  become: true
+  environment: '{{ env }}'
+  roles:
+    - { role: etcd, run_as: master }
+
+- hosts: netplugin-worker
+  become: true
+  environment: '{{ env }}'
+  roles:
+    - { role: etcd, run_as: worker }

--- a/install_scheduler.yml
+++ b/install_scheduler.yml
@@ -1,0 +1,12 @@
+# Install scheduler stack with manager nodes on master nodes and the others as workers
+- hosts: netplugin-master
+  become: true
+  environment: '{{ env }}'
+  roles:
+    - { role: scheduler_stack, docker_api_port: 2385, run_as: master }
+
+- hosts: netplugin-worker
+  become: true
+  environment: '{{ env }}'
+  roles:
+    - { role: scheduler_stack, docker_api_port: 2385, run_as: worker }

--- a/roles/auth_proxy/README.md
+++ b/roles/auth_proxy/README.md
@@ -27,13 +27,3 @@ Example Playbook
   become: true
       roles:
         - { role: auth_proxy, auth_proxy_port: 10000, auth_proxy_datastore: etcd://netmaster:2379 }
-
-License
--------
-
-BSD
-
-Author Information
-------------------
-
-Please see contiv.io for more information.

--- a/roles/auth_proxy/README.md
+++ b/roles/auth_proxy/README.md
@@ -1,0 +1,39 @@
+Role Name
+=========
+
+Role to install Contiv API Proxy and UI
+
+Requirements
+------------
+
+Docker needs to be installed to run the auth proxy container.
+
+Role Variables
+--------------
+
+auth_proxy_image specifies the image with version tag to be used to spin up the auth proxy container.
+auth_proxy_cert, auth_proxy_key specify files to use for the proxy server certificates.
+auth_proxy_port is the host port and auth_proxy_datastore the cluster data store address.
+
+Dependencies
+------------
+
+docker
+
+Example Playbook
+----------------
+
+- hosts: netplugin-node
+  become: true
+      roles:
+        - { role: auth_proxy, auth_proxy_port: 10000, auth_proxy_datastore: etcd://netmaster:2379 }
+
+License
+-------
+
+BSD
+
+Author Information
+------------------
+
+Please see contiv.io for more information.

--- a/roles/auth_proxy/defaults/main.yml
+++ b/roles/auth_proxy/defaults/main.yml
@@ -1,0 +1,6 @@
+auth_proxy_image: "contiv/auth_proxy:1.0.0-alpha"
+auth_proxy_port: 10000
+contiv_certs: "/var/contiv/certs"
+auth_proxy_cert: "{{ contiv_certs }}/auth_proxy_cert.pem"
+auth_proxy_key: "{{ contiv_certs }}/auth_proxy_key.pem"
+auth_proxy_datastore: "{{ cluster_store }}"

--- a/roles/auth_proxy/files/auth-proxy.service
+++ b/roles/auth_proxy/files/auth-proxy.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Contiv Proxy and UI
+After=auditd.service systemd-user-sessions.service time-sync.target docker.service
+
+[Service]
+ExecStart=/usr/bin/auth_proxy.sh start
+ExecStop=/usr/bin/auth_proxy.sh stop
+KillMode=control-group
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/auth_proxy/handlers/main.yml
+++ b/roles/auth_proxy/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for auth_proxy

--- a/roles/auth_proxy/tasks/cleanup.yml
+++ b/roles/auth_proxy/tasks/cleanup.yml
@@ -1,0 +1,4 @@
+---
+
+- name: stop auth-proxy container
+  service: name=auth-proxy state=stopped

--- a/roles/auth_proxy/tasks/main.yml
+++ b/roles/auth_proxy/tasks/main.yml
@@ -1,0 +1,23 @@
+---
+# tasks file for auth_proxy
+
+- name: create cert folder for proxy
+  file: path=/var/contiv/certs state=directory
+
+- name: copy shell script for starting auth-proxy
+  template: src=auth_proxy.j2 dest=/usr/bin/auth_proxy.sh mode=u=rwx,g=rx,o=rx
+
+- name: copy cert for starting auth-proxy
+  copy: src=cert.pem dest=/var/contiv/certs/auth_proxy_cert.pem mode=u=rw,g=r,o=r
+
+- name: copy key for starting auth-proxy
+  copy: src=key.pem dest=/var/contiv/certs/auth_proxy_key.pem mode=u=rw,g=r,o=r
+
+- name: copy systemd units for auth-proxy
+  copy: src=auth-proxy.service dest=/etc/systemd/system/auth-proxy.service
+
+- name: initialize auth-proxy
+  shell: /usr/bin/auth_proxy.sh init
+
+- name: start auth-proxy container
+  service: name=auth-proxy daemon_reload=yes state=started enabled=yes

--- a/roles/auth_proxy/templates/auth_proxy.j2
+++ b/roles/auth_proxy/templates/auth_proxy.j2
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+usage="$0 start"
+if [ $# -ne 1 ]; then
+    echo USAGE: $usage
+    exit 1
+fi
+
+case $1 in
+init)
+    set -e
+
+    /usr/bin/docker run --rm \
+      --net=host {{ auth_proxy_image }} \
+      --data-store-address={{ auth_proxy_datastore }} \
+      --initial-setup
+    ;;
+
+start)
+    set -e
+
+    /usr/bin/docker run --rm \
+      -p 10000:{{ auth_proxy_port }} \
+      --net=host --name=auth-proxy \
+      -e NO_NETMASTER_STARTUP_CHECK=1 \
+      -v /var/contiv:/var/contiv \
+      {{ auth_proxy_image }} \
+      --tls-key-file={{ auth_proxy_key }} \
+      --tls-certificate={{ auth_proxy_cert }} \
+      --data-store-address={{ auth_proxy_datastore }} \
+      --netmaster-address={{ service_vip }}:9999 \
+      --listen-address=:10000 
+    ;;
+
+stop)
+    # don't stop on error
+    /usr/bin/docker stop auth-proxy
+    /usr/bin/docker rm -f -v  auth-proxy
+    ;;
+
+*)
+    echo USAGE: $usage
+    exit 1
+    ;;
+esac

--- a/roles/auth_proxy/tests/inventory
+++ b/roles/auth_proxy/tests/inventory
@@ -1,0 +1,1 @@
+localhost

--- a/roles/auth_proxy/tests/test.yml
+++ b/roles/auth_proxy/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - auth_proxy

--- a/roles/auth_proxy/vars/main.yml
+++ b/roles/auth_proxy/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for auth_proxy

--- a/uninstall_auth_proxy.yml
+++ b/uninstall_auth_proxy.yml
@@ -1,0 +1,23 @@
+---
+# This playbook performs service cleanup for auth_proxy.
+#
+# Note: cleanup is not expected to fail, so we set ignore_errors to yes here
+
+- hosts: netplugin-master
+  become: true
+  tasks:
+    - include_vars: roles/{{ item }}/defaults/main.yml
+      with_items:
+        - "contiv_network"
+        - "contiv_storage"
+        - "swarm"
+        - "kubernetes"
+        - "ucp"
+        - "docker"
+        - "etcd"
+        - "auth_proxy"
+    - include: roles/{{ item }}/tasks/cleanup.yml
+      with_items:
+        - auth_proxy
+      static: no
+      ignore_errors: yes

--- a/uninstall_auth_proxy.yml
+++ b/uninstall_auth_proxy.yml
@@ -8,13 +8,6 @@
   tasks:
     - include_vars: roles/{{ item }}/defaults/main.yml
       with_items:
-        - "contiv_network"
-        - "contiv_storage"
-        - "swarm"
-        - "kubernetes"
-        - "ucp"
-        - "docker"
-        - "etcd"
         - "auth_proxy"
     - include: roles/{{ item }}/tasks/cleanup.yml
       with_items:

--- a/uninstall_contiv.yml
+++ b/uninstall_contiv.yml
@@ -9,10 +9,8 @@
     - include_vars: roles/{{ item }}/defaults/main.yml
       with_items:
         - "contiv_network"
-        - "contiv_storage"
         - "swarm"
         - "kubernetes"
-        - "ucp"
         - "docker"
         - "etcd"
     - include: roles/{{ item }}/tasks/cleanup.yml

--- a/uninstall_contiv.yml
+++ b/uninstall_contiv.yml
@@ -1,0 +1,22 @@
+---
+# This playbook performs service cleanup for contiv network.
+#
+# Note: cleanup is not expected to fail, so we set ignore_errors to yes here
+
+- hosts: all
+  become: true
+  tasks:
+    - include_vars: roles/{{ item }}/defaults/main.yml
+      with_items:
+        - "contiv_network"
+        - "contiv_storage"
+        - "swarm"
+        - "kubernetes"
+        - "ucp"
+        - "docker"
+        - "etcd"
+    - include: roles/{{ item }}/tasks/cleanup.yml
+      with_items:
+        - contiv_network
+      static: no
+      ignore_errors: yes

--- a/uninstall_docker.yml
+++ b/uninstall_docker.yml
@@ -9,10 +9,8 @@
     - include_vars: roles/{{ item }}/defaults/main.yml
       with_items:
         - "contiv_network"
-        - "contiv_storage"
         - "swarm"
         - "kubernetes"
-        - "ucp"
         - "docker"
         - "etcd"
     - include: roles/{{ item }}/tasks/cleanup.yml

--- a/uninstall_docker.yml
+++ b/uninstall_docker.yml
@@ -1,0 +1,22 @@
+---
+# This playbook performs service cleanup for docker.
+#
+# Note: cleanup is not expected to fail, so we set ignore_errors to yes here
+
+- hosts: all
+  become: true
+  tasks:
+    - include_vars: roles/{{ item }}/defaults/main.yml
+      with_items:
+        - "contiv_network"
+        - "contiv_storage"
+        - "swarm"
+        - "kubernetes"
+        - "ucp"
+        - "docker"
+        - "etcd"
+    - include: roles/{{ item }}/tasks/cleanup.yml
+      with_items:
+        - docker
+      static: no
+      ignore_errors: yes

--- a/uninstall_etcd.yml
+++ b/uninstall_etcd.yml
@@ -1,0 +1,22 @@
+---
+# This playbook performs service cleanup for etcd.
+#
+# Note: cleanup is not expected to fail, so we set ignore_errors to yes here
+
+- hosts: all
+  become: true
+  tasks:
+    - include_vars: roles/{{ item }}/defaults/main.yml
+      with_items:
+        - "contiv_network"
+        - "contiv_storage"
+        - "swarm"
+        - "kubernetes"
+        - "ucp"
+        - "docker"
+        - "etcd"
+    - include: roles/{{ item }}/tasks/cleanup.yml
+      with_items:
+        - etcd
+      static: no
+      ignore_errors: yes

--- a/uninstall_etcd.yml
+++ b/uninstall_etcd.yml
@@ -9,10 +9,8 @@
     - include_vars: roles/{{ item }}/defaults/main.yml
       with_items:
         - "contiv_network"
-        - "contiv_storage"
         - "swarm"
         - "kubernetes"
-        - "ucp"
         - "docker"
         - "etcd"
     - include: roles/{{ item }}/tasks/cleanup.yml

--- a/uninstall_scheduler.yml
+++ b/uninstall_scheduler.yml
@@ -1,0 +1,22 @@
+---
+# This playbook performs service cleanup for swarm.
+#
+# Note: cleanup is not expected to fail, so we set ignore_errors to yes here
+
+- hosts: all
+  become: true
+  tasks:
+    - include_vars: roles/{{ item }}/defaults/main.yml
+      with_items:
+        - "contiv_network"
+        - "contiv_storage"
+        - "swarm"
+        - "kubernetes"
+        - "ucp"
+        - "docker"
+        - "etcd"
+    - include: roles/{{ item }}/tasks/cleanup.yml
+      with_items:
+        - swarm
+      static: no
+      ignore_errors: yes

--- a/uninstall_scheduler.yml
+++ b/uninstall_scheduler.yml
@@ -9,10 +9,8 @@
     - include_vars: roles/{{ item }}/defaults/main.yml
       with_items:
         - "contiv_network"
-        - "contiv_storage"
         - "swarm"
         - "kubernetes"
-        - "ucp"
         - "docker"
         - "etcd"
     - include: roles/{{ item }}/tasks/cleanup.yml


### PR DESCRIPTION
The install_* and uninstall_* files allow triggering install and
cleanup actions for specific components. This allows the end user to
specify finer grained installation (only docker, only scheduler, only
contiv etc.)