### PR TITLE
roles/test: bump VirtualBox, Packer and Vagrant

### DIFF
--- a/roles/test/defaults/main.yml
+++ b/roles/test/defaults/main.yml
@@ -2,12 +2,13 @@
 # role variable for the test environment packages
 
 vbox_package_version: "5.1"
-vbox_major_version: "{{ vbox_package_version }}.4"
-vbox_version_ubuntu: "{{ vbox_package_version }}_{{ vbox_major_version }}-110228"
+vbox_major_version: "{{ vbox_package_version }}.14"
+vbox_build_number: "112924"
+vbox_version_ubuntu: "{{ vbox_package_version }}_{{ vbox_major_version }}-{{ vbox_build_number }}"
 vbox_version_ubuntu_dist_version:
     vivid: "{{ vbox_version_ubuntu }}~Ubuntu~trusty"
     wily:  "{{ vbox_version_ubuntu }}~Ubuntu~wily"
     xenial:  "{{ vbox_version_ubuntu }}~Ubuntu~xenial"
-vbox_version_redhat: "{{ vbox_package_version }}-{{ vbox_major_version }}_110228"
-vagrant_version: "1.8.5"
-packer_version: "0.10.0"
+vbox_version_redhat: "{{ vbox_package_version }}-{{ vbox_major_version }}_{{ vbox_build_number }}"
+vagrant_version: "1.9.1"
+packer_version: "0.12.2"


### PR DESCRIPTION
This PR updates the test role to install the latest versions of the tools mentioned above. This is needed to avoid having to edit the role by hand.