### PR TITLE
Cleanup docker etcd state

### DIFF
--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -14,3 +14,5 @@ docker_cs_engine_supported_versions_ubuntu:
     "Core": [""] # needed for redhat installations due to templating
     "Maipo": [""] # needed for redhat installations due to templating
 docker_mount_flags: "shared"
+docker_reset_container_state: false
+docker_reset_image_state: false

--- a/roles/docker/tasks/cleanup.yml
+++ b/roles/docker/tasks/cleanup.yml
@@ -1,6 +1,14 @@
 ---
 # This play contains tasks for cleaning up docker
 
+- name: remove all containers
+  shell: unset DOCKER_HOST && docker rm -f -v $(docker ps -a -q)
+  when: docker_reset_container_state == true
+
+- name: remove all images
+  shell: unset DOCKER_HOST && docker rmi -f $(docker images -q)
+  when: docker_reset_image_state == true
+
 - name: stop docker
   service: name=docker state=stopped
 

--- a/roles/etcd/defaults/main.yml
+++ b/roles/etcd/defaults/main.yml
@@ -11,3 +11,4 @@ etcd_version: "v2.3.7"
 etcd_heartbeat_interval: 1000
 etcd_election_timeout: 10000
 etcd_data_dir: /var/lib/etcd
+etcd_reset_state: false

--- a/roles/etcd/defaults/main.yml
+++ b/roles/etcd/defaults/main.yml
@@ -10,3 +10,4 @@ etcd_rule_comment: "etcd traffic"
 etcd_version: "v2.3.7"
 etcd_heartbeat_interval: 1000
 etcd_election_timeout: 10000
+etcd_data_dir: /var/lib/etcd

--- a/roles/etcd/tasks/cleanup.yml
+++ b/roles/etcd/tasks/cleanup.yml
@@ -4,6 +4,10 @@
 - name: stop etcd
   service: name=etcd state=stopped
 
+- name: cleanup etcd state
+  file: state=absent path={{ etcd_data_dir }}
+  when: etcd_cleanup_state == true
+
 - name: cleanup iptables for etcd
   shell: iptables -D INPUT -p tcp --dport {{ item }} -j ACCEPT -m comment --comment "{{ etcd_rule_comment }} ({{ item }})"
   become: true

--- a/roles/etcd/templates/etcd.j2
+++ b/roles/etcd/templates/etcd.j2
@@ -172,6 +172,7 @@ start)
     #start etcd
     echo "==> starting etcd with environment:" `env`
     /usr/bin/docker run -t --rm --net=host --name etcd \
+        -v ${ETCD_DATA_DIR}:${ETCD_DATA_DIR} \
         -e ETCD_NAME=${ETCD_NAME} \
         -e ETCD_DATA_DIR=${ETCD_DATA_DIR} \
         -e ETCD_INITIAL_CLUSTER_TOKEN=${ETCD_INITIAL_CLUSTER_TOKEN} \


### PR DESCRIPTION
This change is made on top of https://github.com/contiv/ansible/pull/324, as we need the etcd state to cleanup. Fixes #320 and https://github.com/contiv/install/issues/12.