### PR TITLE
Passing netmaster_port paramter to netmaster initialization

### DIFF
--- a/roles/contiv_network/templates/netmaster.j2
+++ b/roles/contiv_network/templates/netmaster.j2
@@ -1,1 +1,1 @@
-NETMASTER_ARGS="--cluster-mode {{netplugin_mode}} -cluster-store {{cluster_store}} "
+NETMASTER_ARGS="--cluster-mode {{netplugin_mode}} -cluster-store {{cluster_store}} -listen-url :{{ netmaster_port }}"


### PR DESCRIPTION
Fixes https://github.com/contiv/ansible/issues/299. We already had the netmaster_port being used as a parameter,  but it was only used to open the ports. Not adding it to netmaster as an option as well.