### PR TITLE
roles/etcd: bump etcd to 2.3.8

### DIFF
--- a/roles/etcd/defaults/main.yml
+++ b/roles/etcd/defaults/main.yml
@@ -7,7 +7,7 @@ etcd_peer_port1: 2380
 etcd_peer_port2: 7001
 etcd_peers_group: "service-master"
 etcd_rule_comment: "etcd traffic"
-etcd_version: "v2.3.7"
+etcd_version: "v2.3.8"
 etcd_heartbeat_interval: 1000
 etcd_election_timeout: 10000
 etcd_data_dir: /var/lib/etcd


### PR DESCRIPTION
This PR bumps etcd to 2.3.8. This version of etcd is compiled with Go 1.7.5. 2.3.8 includes a fix for data corruption when the disk is full.

https://github.com/coreos/etcd/releases/tag/v2.3.8