### PR TITLE
Enable Ubuntu 16.04 with Docker 1.12+

### DIFF
--- a/roles/contiv_network/tasks/ovs.yml
+++ b/roles/contiv_network/tasks/ovs.yml
@@ -36,40 +36,18 @@
   tags:
     - prebake-for-dev
 
-- name: copy ovs common file (debian)
-  copy: src={{ contiv_standalone_binaries }}/v1dvgoboo5zgqrtn6tu27vxeqtdo2bdl.deb dest=/tmp/ovs-common.deb 
-  when: ansible_os_family == "Debian" and contiv_network_local_install == True
-
-- name: copy ovs switch file (debian)
-  copy: src={{ contiv_standalone_binaries }}/ymbuwvt2qprs4tquextw75b82hyaxwon.deb dest=/tmp/ovs-switch.deb 
-  when: ansible_os_family == "Debian" and contiv_network_local_install == True
-
-- name: download ovs binaries (debian)
-  get_url:
-    validate_certs: "{{ validate_certs }}"
-    dest: "{{ item.dest }}"
-    url: "{{ item.url }}"
-  with_items:
-    - {
-        url: "https://cisco.box.com/shared/static/v1dvgoboo5zgqrtn6tu27vxeqtdo2bdl.deb",
-        dest: /tmp/ovs-common.deb
-      }
-    - {
-        url: "https://cisco.box.com/shared/static/ymbuwvt2qprs4tquextw75b82hyaxwon.deb",
-        dest: /tmp/ovs-switch.deb
-      }
-  when: ansible_os_family == "Debian" and contiv_network_local_install == False
-  tags:
-    - prebake-for-dev
-
 - name: install ovs-common (debian)
-  apt: "deb=/tmp/ovs-common.deb"
+  apt: 
+      name: openvswitch-common=2.5.0-0ubuntu1
+      state: present
   when: ansible_os_family == "Debian"
   tags:
     - prebake-for-dev
 
 - name: install ovs (debian)
-  apt: "deb=/tmp/ovs-switch.deb"
+  apt: 
+      name: openvswitch-switch=2.5.0-0ubuntu1
+      state: present
   when: ansible_os_family == "Debian"
   tags:
     - prebake-for-dev

--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -9,8 +9,8 @@ docker_device: ""
 docker_device_size: "10000MB"
 docker_device_metadata_size: "1000MB"
 docker_cs_engine_supported_versions_ubuntu:
-    "wily": [ "1.10", "1.11" ]
-    "xenial": [ "1.11" ]
+    "wily": [ "1.10", "1.11", "1.12", "1.13" ]
+    "xenial": [ "1.11", "1.12", "1.13" ]
     "Core": [""] # needed for redhat installations due to templating
     "Maipo": [""] # needed for redhat installations due to templating
 docker_mount_flags: "shared"

--- a/roles/docker/tasks/ubuntu_install_tasks.yml
+++ b/roles/docker/tasks/ubuntu_install_tasks.yml
@@ -16,3 +16,9 @@
 
 - name: install docker (debian)
   shell: curl https://get.docker.com | sed 's/docker-engine/--force-yes docker-engine={{ docker_version }}-0~{{ ansible_distribution_release }}/' | bash
+  when: "{{ docker_version | version_compare('1.12', '<') }}"
+
+- name: install docker 1.12+ (debian)
+  shell: curl https://get.docker.com | sed 's/docker-engine/--force-yes docker-engine={{ docker_version }}-0~ubuntu-{{ ansible_distribution_release }}/' | bash
+  when: "{{ docker_version | version_compare('1.12', '>=') }}"
+


### PR DESCRIPTION
The docker-engine apt repo name had been changed to include ubuntu-. Updating accordingly.
Also updated OVS debian install to pull the deb directly