### PR TITLE
roles/contiv_network/tasks/ovs.yml: adjust version

### DIFF
--- a/roles/contiv_network/tasks/ovs.yml
+++ b/roles/contiv_network/tasks/ovs.yml
@@ -38,7 +38,7 @@
 
 - name: install ovs-common (debian)
   apt: 
-      name: openvswitch-common=2.5.0-0ubuntu1
+      name: openvswitch-common=2.5.*
       state: present
   when: ansible_os_family == "Debian"
   tags:
@@ -46,7 +46,7 @@
 
 - name: install ovs (debian)
   apt: 
-      name: openvswitch-switch=2.5.0-0ubuntu1
+      name: openvswitch-switch=2.5.*
       state: present
   when: ansible_os_family == "Debian"
   tags:


### PR DESCRIPTION
The Ubuntu packages have been bumped to 2.5.2 recently. This means the ansible playbooks would fail on Ubuntu because the specific version of this package isn't available any more.