### PR TITLE
aws.tf: use ami-7c280d1c by default

### DIFF
--- a/aws.tf
+++ b/aws.tf
@@ -88,7 +88,7 @@ variable "ssh_keypair" {}
 variable "key_path" {}
 
 variable "aws_ami" {
-    default = "ami-af4333cf" # CentOS 7 AMI
+    default = "ami-7c280d1c" # CentOS 7 AMI
 }
 
 variable "aws_instance_type" {


### PR DESCRIPTION
This small PR bumps the AMI to the 2017-Mar-31 official CentOS image.