### PR TITLE
Update the localhost /etc/hosts matching to be specific to localhost …

### DIFF
--- a/roles/contiv_network/tasks/services.yml
+++ b/roles/contiv_network/tasks/services.yml
@@ -33,7 +33,7 @@
     regexp: "{{ item.regexp }}"
     state: present
   with_items:
-    - { line: '127.0.0.1 localhost', regexp: '^127\.0\.0\.1' }
+    - { line: '127.0.0.1 localhost', regexp: '^127\.0\.0\.1 .*localhost$' }
     - { line: '{{ node_addr }} {{ ansible_hostname }}', regexp: ' {{ ansible_hostname }}$' }
 
 - name: copy environment file for netmaster


### PR DESCRIPTION
Update the localhost /etc/hosts matching to be specific to localhost  entry

Fixes https://github.com/contiv/install/issues/221

We made a change in 1.1 to point netmaster to 127.0.0.1 to allow multiple master nodes to target their own current netmaster instance. This localhost entry addition was overwriting that due to the regex matching any 127.0.0.1 entries. This PR fixes the issue. 