### PR TITLE
Vagrantfile: use linked clones in Vagrant 1.8 or >

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -48,7 +48,7 @@ Vagrant.configure(2) do |config|
                 vb.customize ['modifyvm', :id, '--paravirtprovider', 'kvm']
                 vb.customize ['modifyvm', :id, '--natdnshostresolver1', 'on']
                 vb.customize ['modifyvm', :id, '--natdnsproxy1', 'on']
-                vb.linked_clone = true if Vagrant::VERSION =~ /^1.8/
+                vb.linked_clone = true if Vagrant::VERSION >= "1.8"
             end
 
             if ansible_groups["devtest"] == nil then


### PR DESCRIPTION
Just to be clear, the current code only enables this feature for 1.8.x ... people running 1.9.x wouldn't have it enabled.  This PR turns it on for 1.8+

Signed-off-by: Bill Robinson <dseevr@users.noreply.github.com>