### PR TITLE
Issue 975: Restarting docker service on a worker node puts the Contiv netplugin on the disabled state

### DIFF
--- a/roles/contiv_network/files/v2plugin.service
+++ b/roles/contiv_network/files/v2plugin.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=enable v2plugin after etcd 
+After=docker.service etcd.service
+PartOf=etcd.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/v2plugin.sh
+StandardOutput=journal
+[Install]
+WantedBy=multi-user.target

--- a/roles/contiv_network/files/v2plugin.sh
+++ b/roles/contiv_network/files/v2plugin.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -euxo pipefail
+while [ true ]
+do
+        ID="$(docker plugin ls  | awk '/contiv/ {print $2}')"
+        STATUS="$(docker plugin ls  | awk '{print $8}')"
+        if [ $STATUS != true ]; then
+                docker plugin enable $ID
+                sleep 1
+        else
+                break
+        fi
+done

--- a/roles/contiv_network/tasks/v2plugin.yml
+++ b/roles/contiv_network/tasks/v2plugin.yml
@@ -17,6 +17,15 @@
     /usr/bin/docker plugin install --grant-all-permissions {{contiv_v2plugin_image}} ctrl_ip={{node_addr}} control_url={{node_addr}}:{{netmaster_port}} vxlan_port={{vxlan_port}} iflist={{netplugin_if}} plugin_name={{contiv_v2plugin_image}} cluster_store={{cluster_store}} plugin_role={{run_as}}
   when: v2plugin_installed|failed
 
+- name: copy v2plugin.sh file
+  copy: src=v2plugin.sh dest=/usr/bin/v2plugin.sh mode=u=rwx,g=rx,o=rx
+
+- name: copy systemd units for v2plugin
+  copy: src=v2plugin.service dest=/etc/systemd/system/v2plugin.service
+
+- name: start v2plugin
+  systemd: name=v2plugin  enabled=yes
+
 - name: for v2 plugin, extract netctl binary
   shell: tar vxjf {{ contiv_network_dest_file }} netctl contrib/completion/bash/netctl
   args:


### PR DESCRIPTION
Issue :restarting docker service at master node cause contiv-plugin into failed state . 

Root-cause : Due cyclic dependency between docker daemon,  netplugin and etcd. contiv plugin failed to startup. contiv plugin  has dependency on etcd and etcd has dependency on    docker daemon while docker daemon try to bring up netplugin before before etcd . User has to run docker plugin enable command manually to enable it again. 
To fix this issue, add on v2plugin.service file which restart v2plugin again after etcd.service . First attempt of docker daemon show failure but eventually after etcd  service , v2plugin service would trigger plugin enable command again.  With this workaround user won't notice any failure . 