### PR TITLE
Fix enabling v2plugin on docker/etcd (re)start

### DIFF
--- a/roles/contiv_network/files/v2plugin.sh
+++ b/roles/contiv_network/files/v2plugin.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
+
+# Keep trying forever to "docker plugin enable" the contiv plugin
+
 set -euxo pipefail
 while [ true ]
 do
         ID="$(docker plugin ls  | awk '/contiv/ {print $2}')"
         STATUS="$(docker plugin ls  | awk '{print $8}')"
         if [ $STATUS != true ]; then
-                docker plugin enable $ID
-                sleep 1
+                docker plugin enable $ID || sleep 1
         else
                 break
         fi

--- a/roles/etcd/files/etcd.service
+++ b/roles/etcd/files/etcd.service
@@ -3,13 +3,10 @@ Description=Etcd
 After=auditd.service systemd-user-sessions.service time-sync.target docker.service
 
 [Service]
-Restart=on-failure
-RestartSec=10s
 ExecStart=/usr/bin/etcd.sh start
 ExecStop=/usr/bin/etcd.sh stop
 KillMode=control-group
-Restart=on-failure
-RestartSec=10
+Restart=always
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The problem was the plugin enable would fail because netplugin was not
ready because etcd was not ready.  The script did not expect a failure
to enable and bailed.

This change keeps retying to enable the plugin as a quick fix

```
             ┌──────────┐
             │  Docker  │
             │  Starts  │◀─────────────┐
             │          │              │
             └──────────┘              │
                   │                   │
      ┌────────────┴────────────┐      │
      ▼                         ▼      │
┌──────────┐              ┌──────────┐ │
│   etcd   │     sleeps   │netplugin │ │
│starts in │◀────until ───│  starts  │ │
│container │   available  │          │ │
└──────────┘              └──────────┘ │
      │                                │
    after etcd                         │
 starts, kicks off                 Checks if
 v2plugin.service                  plugin is
          │                        enabled,
          ▼                       enables if
 ┌─────────────────┐                  not
 │                 │                   │
 │v2plugin.service │                   │
 │   v2plugin.sh   │───────────────────┘
 │                 │
 └─────────────────┘
```

Signed-off-by: Chris Plock <chrisplo@cisco.com>