### PR TITLE
contiv iptables rules apply after firewalld

### DIFF
--- a/roles/auth_proxy/files/contivRule.service
+++ b/roles/auth_proxy/files/contivRule.service
@@ -3,7 +3,11 @@ Description=run contiv rule service
 
 [Service]
 Type=oneshot
+# firewalld acquires the lock by 3s but isn't finished yet
+# but contivRule.sh wait for the lock release
+ExecStartPre=/bin/sleep 3
 ExecStart=/usr/bin/contivRule.sh
 StandardOutput=journal
+
 [Install]
-WantedBy=multi-user.target
+WantedBy=multi-user.target firewalld.service

--- a/roles/auth_proxy/files/contivRule.sh
+++ b/roles/auth_proxy/files/contivRule.sh
@@ -3,13 +3,12 @@ set -e
 IFS="
 "
 rules_file="/etc/contiv/rules.conf"
-if [ -f "$rules_file" ]
-then
+if [ -f "$rules_file" ]; then
     while read line; do
-        eval iptables $line
+        eval iptables -w 10 $line
     done < $rules_file
 else 
     mkdir -p "/etc/contiv"
     touch $rules_file 
-    iptables -S | grep "contiv" > $rules_file
+    iptables -S | sed '/contiv/!d;s/^-A/-I/' > $rules_file
 fi


### PR DESCRIPTION
If firewalld is started, run contivRule.sh after it, but delay it a few
seconds to let firewalld acquire the iptables lock.  Add -w to wait for
lock release so it can update.

Signed-off-by: Chris Plock <chrisplo@cisco.com>