### PR TITLE
support building branched v2plugin at install time

### DIFF
--- a/roles/contiv_network/defaults/main.yml
+++ b/roles/contiv_network/defaults/main.yml
@@ -4,7 +4,8 @@
 # NOTE: Role defaults have a lower priority than inventory vars.
 # Include variables which need to be overridden by inventory vars here.
 
-contiv_v2plugin_image: "contiv/v2plugin:1.0.3"
+contiv_v2plugin_image: "contiv/v2plugin:{{ contiv_network_version }}"
+contiv_v2plugin_tar_filename: "v2plugin-{{ contiv_network_version }}.tar.gz"
 
 contiv_network_mode: "standalone" # Accepted values: standalone, aci
 netplugin_mode: "docker" # Accepted values: docker, kubernetes
@@ -28,7 +29,7 @@ netplugin_rule_comment: "contiv_network traffic"
 
 aci_gw_image: "contiv/aci-gw"
 # contiv tar files to get netplugin binary
-contiv_network_version: "1.0.3"
+contiv_network_version: "1.1.7"
 contiv_network_tar_file: "netplugin-{{ contiv_network_version }}.tar.bz2"
 contiv_network_src_tar_file: "{{ contiv_standalone_binaries }}/{{ contiv_network_tar_file }}"
 contiv_network_src_file: "https://github.com/contiv/netplugin/releases/download/{{ contiv_network_version }}/{{ contiv_network_tar_file }}"

--- a/roles/contiv_network/tasks/main.yml
+++ b/roles/contiv_network/tasks/main.yml
@@ -37,6 +37,9 @@
 - name: ensure netplugin directory exists
   file: path=/usr/bin/contiv/netplugin state=directory
 
+- name: create links for netctl binary
+  file: src=/usr/bin/contiv/netplugin/netctl dest=/usr/bin/netctl state=link force=yes
+
 - include: services.yml
   when: contiv_v2plugin_install == False
 
@@ -47,9 +50,6 @@
 # cni plugin for contiv, which is available after extraction of binaries
 - include: k8s_tasks.yml
   when: scheduler_provider == "kubernetes"
-
-- name: create links for netctl binary
-  file: src=/usr/bin/contiv/netplugin/netctl dest=/usr/bin/netctl state=link force=yes
 
 - name: copy bash auto complete file for netctl
   file: src=/usr/bin/contiv/netplugin/contrib/completion/bash/netctl dest=/etc/bash_completion.d/netctl state=link
@@ -68,4 +68,4 @@
 - name: set fwd mode
   shell: netctl --netmaster {{ netctl_url }} global set --fwd-mode "{{ fwd_mode }}"
   when: (run_as == "master")
-  run_once: true 
+  run_once: true

--- a/roles/contiv_network/tasks/main.yml
+++ b/roles/contiv_network/tasks/main.yml
@@ -42,9 +42,11 @@
 
 - include: services.yml
   when: contiv_v2plugin_install == False
+  static: no
 
 - include: v2plugin.yml
   when: contiv_v2plugin_install == True
+  static: no
 
 # k8s tasks are run after extracting the binaries as we need to copy the k8s
 # cni plugin for contiv, which is available after extraction of binaries

--- a/roles/contiv_network/tasks/v2plugin.yml
+++ b/roles/contiv_network/tasks/v2plugin.yml
@@ -1,8 +1,13 @@
 ---
 # This role contains tasks for starting docker plugin service
 
+- name: for v2 plugin, extract netctl binaries
+  shell: tar vxjf {{ contiv_network_dest_file }} netctl contrib/completion/bash/netctl
+  args:
+    chdir: /usr/bin/contiv/netplugin
+
 - name: create the directories needed for ovs
-  shell: mkdir -p {{ item }}
+  file: state=directory path={{ item }}
   with_items:
     - "/etc/openvswitch"
     - "/var/log/openvswitch"
@@ -10,12 +15,19 @@
 - name: check if v2plugin has been installed on {{ run_as }} nodes
   shell: docker plugin ls | grep -n {{ contiv_v2plugin_image }}
   register: v2plugin_installed
+  changed_when: no
   ignore_errors: True
 
-- name: install v2plugin on {{ run_as }} nodes
+- name: check if v2plugin archive is in the contiv_cache
+  local_action: stat path=/var/contiv_cache/{{ contiv_v2plugin_tar_filename }} follow=yes
+  register: v2plugin_archive_stat
+
+- name: install v2plugin on {{ run_as }} nodes from dockerhub
   shell: >
     /usr/bin/docker plugin install --grant-all-permissions {{contiv_v2plugin_image}} ctrl_ip={{node_addr}} control_url={{node_addr}}:{{netmaster_port}} vxlan_port={{vxlan_port}} iflist={{netplugin_if}} plugin_name={{contiv_v2plugin_image}} cluster_store={{cluster_store}} plugin_role={{run_as}} fwd_mode={{ fwd_mode }}
-  when: v2plugin_installed|failed
+  when:
+    - v2plugin_installed|failed
+    - not v2plugin_archive_stat.stat.exists
 
 - name: copy v2plugin.sh file
   copy: src=v2plugin.sh dest=/usr/bin/v2plugin.sh mode=u=rwx,g=rx,o=rx
@@ -23,10 +35,12 @@
 - name: copy systemd units for v2plugin
   copy: src=v2plugin.service dest=/etc/systemd/system/v2plugin.service
 
-- name: start v2plugin
-  systemd: name=v2plugin  enabled=yes
+- name: enable v2plugin
+  systemd: name=v2plugin enabled=yes
 
-- name: for v2 plugin, extract netctl binary
-  shell: tar vxjf {{ contiv_network_dest_file }} netctl contrib/completion/bash/netctl
-  args:
-    chdir: /usr/bin/contiv/netplugin
+- name: include v2plugin install from contiv_cache
+  include: v2plugin_local_install.yml
+  when:
+    - v2plugin_installed|failed
+    - v2plugin_archive_stat.stat.exists
+  static: no

--- a/roles/contiv_network/tasks/v2plugin_local_install.yml
+++ b/roles/contiv_network/tasks/v2plugin_local_install.yml
@@ -1,0 +1,38 @@
+- name: Remove v2plugin rootfs directory
+  file: state=absent path=/var/lib/v2plugin/rootfs
+
+- name: Create v2plugin rootfs directory
+  file: state=directory path=/var/lib/v2plugin/rootfs
+
+- name: Unpack v2plugin from local archive
+  unarchive:
+    src: "/var/contiv_cache/{{ contiv_v2plugin_tar_filename }}"
+    dest: /var/lib/v2plugin/rootfs/
+
+- name: Copy config.json for plugin container
+  copy: src=/var/contiv_cache/config.json dest=/var/lib/v2plugin
+
+- name: Create v2plugin from exploded archive
+  shell: >
+    docker plugin create {{ contiv_v2plugin_image }} /var/lib/v2plugin/
+
+- name: Set v2plugin settings
+  shell: >
+    docker plugin set {{ contiv_v2plugin_image }}
+    ctrl_ip={{ node_addr }}
+    control_url={{ node_addr }}:{{ netmaster_port }}
+    vxlan_port={{ vxlan_port }}
+    iflist={{ netplugin_if }}
+    plugin_name={{ contiv_v2plugin_image }}
+    cluster_store={{ cluster_store }}
+    plugin_role={{ run_as }}
+    fwd_mode={{ fwd_mode }}
+
+- name: Remove v2plugin rootfs
+  file: state=absent path=/var/lib/v2plugin/rootfs
+
+- name: Remove v2plugin config.json
+  file: state=absent path=/var/lib/v2plugin/config.json
+
+- name: start v2plugin
+  systemd: name=v2plugin state=started

--- a/roles/contiv_network/tasks/v2plugin_local_install.yml
+++ b/roles/contiv_network/tasks/v2plugin_local_install.yml
@@ -1,38 +1,42 @@
-- name: Remove v2plugin rootfs directory
-  file: state=absent path=/var/lib/v2plugin/rootfs
+- name: Create temp directory for building v2plugin
+  tempfile: state=directory suffix=-v2plugin
+  register: v2plugin_temp_dir
 
-- name: Create v2plugin rootfs directory
-  file: state=directory path=/var/lib/v2plugin/rootfs
+- block:
+    - name: Allow Docker to read the tmpdir
+      file: path={{ v2plugin_temp_dir.path }} group=docker mode=750
 
-- name: Unpack v2plugin from local archive
-  unarchive:
-    src: "/var/contiv_cache/{{ contiv_v2plugin_tar_filename }}"
-    dest: /var/lib/v2plugin/rootfs/
+    - name: Create v2plugin rootfs directory
+      file: state=directory path={{ v2plugin_temp_dir.path }}/rootfs
 
-- name: Copy config.json for plugin container
-  copy: src=/var/contiv_cache/config.json dest=/var/lib/v2plugin
+    - name: Unpack v2plugin from local archive
+      unarchive:
+        src: "/var/contiv_cache/{{ contiv_v2plugin_tar_filename }}"
+        dest: "{{ v2plugin_temp_dir.path }}/rootfs/"
 
-- name: Create v2plugin from exploded archive
-  shell: >
-    docker plugin create {{ contiv_v2plugin_image }} /var/lib/v2plugin/
+    - name: Copy config.json for plugin container
+      copy: src=/var/contiv_cache/config.json dest={{ v2plugin_temp_dir.path }}
 
-- name: Set v2plugin settings
-  shell: >
-    docker plugin set {{ contiv_v2plugin_image }}
-    ctrl_ip={{ node_addr }}
-    control_url={{ node_addr }}:{{ netmaster_port }}
-    vxlan_port={{ vxlan_port }}
-    iflist={{ netplugin_if }}
-    plugin_name={{ contiv_v2plugin_image }}
-    cluster_store={{ cluster_store }}
-    plugin_role={{ run_as }}
-    fwd_mode={{ fwd_mode }}
+    - name: Create v2plugin from exploded archive
+      shell: >
+        docker plugin create {{ contiv_v2plugin_image }}
+        {{ v2plugin_temp_dir.path }}
 
-- name: Remove v2plugin rootfs
-  file: state=absent path=/var/lib/v2plugin/rootfs
+    - name: Set v2plugin settings
+      shell: >
+        docker plugin set {{ contiv_v2plugin_image }}
+        ctrl_ip={{ node_addr }}
+        control_url={{ node_addr }}:{{ netmaster_port }}
+        vxlan_port={{ vxlan_port }}
+        iflist={{ netplugin_if }}
+        plugin_name={{ contiv_v2plugin_image }}
+        cluster_store={{ cluster_store }}
+        plugin_role={{ run_as }}
+        fwd_mode={{ fwd_mode }}
 
-- name: Remove v2plugin config.json
-  file: state=absent path=/var/lib/v2plugin/config.json
+  always:
+    - name: Remove v2plugin rootfs
+      file: state=absent path={{ v2plugin_temp_dir.path }}
 
 - name: start v2plugin
   systemd: name=v2plugin state=started


### PR DESCRIPTION
Adds a series of tasks in an include if v2plugin is to be built on the
target machine

install v2plugin only when not doing a local v2plugin build

netctl link for /usr/bin moved earlier as needed by startcontiv in the
v2plugin

Drive-by:
* contiv_v2plugin_image now defaults to contiv_network_version
* contiv_network_version default bumped to 1.1.7
* use file module to create directory

Signed-off-by: Chris Plock <chrisplo@cisco.com>