### PR TITLE
swarm's etcd on workers should be 127.0.0.1

### DIFF
--- a/roles/swarm/defaults/main.yml
+++ b/roles/swarm/defaults/main.yml
@@ -5,3 +5,4 @@ swarm_api_port: 2375
 swarm_version: "1.2.5"
 swarm_rule_comment: "contiv_swarm traffic"
 swarm_strategy: spread
+swarm_etcd_url: "{{ node_addr if run_as == 'master' else '127.0.0.1' }}"

--- a/roles/swarm/templates/swarm.j2
+++ b/roles/swarm/templates/swarm.j2
@@ -21,7 +21,7 @@ start)
     /usr/bin/docker run -t --net=host --name=swarm-agent \
         swarm:{{ swarm_version }} join \
         --advertise={{ node_addr }}:{{ docker_api_port }} \
-        etcd://{{ node_addr }}:{{ etcd_client_port1 }}
+        etcd://{{ swarm_etcd_url }}:{{ etcd_client_port1 }}
     ;;
 
 stop)


### PR DESCRIPTION
old code had etcd_proxy listen on all interfaces, #376
removed the ETCD_LISTEN_CLIENT_URLS env var that configured that.

Then the proxy only listens on 127.0.0.1, but swarm startup script was
pointing to the control interface's IP.

Signed-off-by: Chris Plock <chrisplo@cisco.com>