### PR TITLE
Update ansible roles for netplugin, netmaster updated CLI

### DIFF
--- a/roles/contiv_network/defaults/main.yml
+++ b/roles/contiv_network/defaults/main.yml
@@ -13,7 +13,8 @@ fwd_mode: "bridge" #Accepted values: bridge , routing
 listen_url: ":9999"
 control_url: ":9999"
 netctl_url: "http://netmaster:9999"
-cluster_store: "etcd://127.0.0.1:2379"
+cluster_store_url: "http://127.0.0.1:2379"
+cluster_store_driver: etcd
 contiv_standalone_binaries: "/var/contiv_cache"
 ofnet_master_port: 9001
 ofnet_agent_port1: 9002

--- a/roles/contiv_network/files/netmaster.service
+++ b/roles/contiv_network/files/netmaster.service
@@ -4,7 +4,7 @@ After=auditd.service systemd-user-sessions.service time-sync.target etcd.service
 
 [Service]
 EnvironmentFile=/etc/default/netmaster
-ExecStart=/usr/bin/netmaster $NETMASTER_ARGS
+ExecStart=/usr/bin/netmaster
 KillMode=control-group
 Restart=on-failure
 RestartSec=10

--- a/roles/contiv_network/files/netplugin.service
+++ b/roles/contiv_network/files/netplugin.service
@@ -4,7 +4,7 @@ After=auditd.service systemd-user-sessions.service time-sync.target etcd.service
 
 [Service]
 EnvironmentFile=/etc/default/netplugin
-ExecStart=/usr/bin/netplugin $NETPLUGIN_ARGS
+ExecStart=/usr/bin/netplugin
 ExecStopPost=/usr/bin/rm -f /run/docker/plugins/netplugin.sock
 KillMode=control-group
 Restart=on-failure

--- a/roles/contiv_network/tasks/main.yml
+++ b/roles/contiv_network/tasks/main.yml
@@ -25,13 +25,13 @@
 
 - name: copy contiv binaries
   copy: src="{{ contiv_standalone_binaries }}/{{ contiv_network_tar_file }}" dest="{{ contiv_network_dest_file }}"
-  when: contiv_network_local_install == True 
+  when: contiv_network_local_install == True
 
 - name: download contiv binaries
   get_url:
     validate_certs: "{{ validate_certs }}"
     url: "{{ contiv_network_src_file }}"
-    dest: "{{ contiv_network_dest_file }}" 
+    dest: "{{ contiv_network_dest_file }}"
   when: contiv_network_local_install == False
 
 - name: ensure netplugin directory exists

--- a/roles/contiv_network/tasks/v2plugin.yml
+++ b/roles/contiv_network/tasks/v2plugin.yml
@@ -24,7 +24,21 @@
 
 - name: install v2plugin on {{ run_as }} nodes from dockerhub
   shell: >
-    /usr/bin/docker plugin install --grant-all-permissions {{contiv_v2plugin_image}} ctrl_ip={{node_addr}} control_url={{node_addr}}:{{netmaster_port}} vxlan_port={{vxlan_port}} iflist={{netplugin_if}} plugin_name={{contiv_v2plugin_image}} cluster_store={{cluster_store}} plugin_role={{run_as}} fwd_mode={{ fwd_mode }}
+    /usr/bin/docker plugin install --grant-all-permissions {{contiv_v2plugin_image}}
+    CONTIV_ROLE={{ (run_as == 'master') | ternary('netmaster', 'netplugin') }}
+    CONTIV_NETPLUGIN_CONTROL_IP={{node_addr}}
+    CONTIV_NETPLUGIN_FORWARD_MODE={{ fwd_mode }}
+    CONTIV_NETPLUGIN_MODE=docker
+    CONTIV_NETPLUGIN_VXLAN_PORT={{vxlan_port}}
+    CONTIV_NETPLUGIN_VLAN_UPLINKS={{netplugin_if}}
+    CONTIV_NETPLUGIN_NET_MODE={{ (fwd_mode == 'bridge') | ternary('vlan', 'vxlan') }}
+    {{ (cluster_store_driver == 'etcd') | ternary('CONTIV_NETPLUGIN_ETCD_ENDPOINTS', 'CONTIV_NETPLUGIN_CONSUL_ENDPOINTS') }}={{ cluster_store_url }}
+    CONTIV_NETMASTER_NET_MODE={{ (fwd_mode == 'bridge') | ternary('vlan', 'vxlan') }}
+    CONTIV_NETMASTER_PLUGIN_NAME={{contiv_v2plugin_image}}
+    CONTIV_NETMASTER_FORWARD_MODE={{ fwd_mode }}
+    CONTIV_NETMASTER_INTERNAL_ADDRESS={{node_addr}}:{{netmaster_port}}
+    CONTIV_NETMASTER_MODE=docker
+    {{ (cluster_store_driver == 'etcd') | ternary('CONTIV_NETMASTER_ETCD_ENDPOINTS', 'CONTIV_NETMASTER_CONSUL_ENDPOINTS') }}={{ cluster_store_url }}
   when:
     - v2plugin_installed|failed
     - not v2plugin_archive_stat.stat.exists

--- a/roles/contiv_network/tasks/v2plugin_local_install.yml
+++ b/roles/contiv_network/tasks/v2plugin_local_install.yml
@@ -25,14 +25,20 @@
     - name: Set v2plugin settings
       shell: >
         docker plugin set {{ contiv_v2plugin_image }}
-        ctrl_ip={{ node_addr }}
-        control_url={{ node_addr }}:{{ netmaster_port }}
-        vxlan_port={{ vxlan_port }}
-        iflist={{ netplugin_if }}
-        plugin_name={{ contiv_v2plugin_image }}
-        cluster_store={{ cluster_store }}
-        plugin_role={{ run_as }}
-        fwd_mode={{ fwd_mode }}
+        CONTIV_ROLE={{ (run_as == 'master') | ternary('netmaster', 'netplugin') }}
+        CONTIV_NETPLUGIN_CONTROL_IP={{node_addr}}
+        CONTIV_NETPLUGIN_FORWARD_MODE={{ fwd_mode }}
+        CONTIV_NETPLUGIN_MODE=docker
+        CONTIV_NETPLUGIN_VXLAN_PORT={{vxlan_port}}
+        CONTIV_NETPLUGIN_VLAN_UPLINKS={{netplugin_if}}
+        CONTIV_NETPLUGIN_NET_MODE={{ (fwd_mode == 'bridge') | ternary('vlan', 'vxlan') }}
+        {{ (cluster_store_driver == 'etcd') | ternary('CONTIV_NETPLUGIN_ETCD_ENDPOINTS', 'CONTIV_NETPLUGIN_CONSUL_ENDPOINTS') }}={{ cluster_store_url }}
+        CONTIV_NETMASTER_NET_MODE={{ (fwd_mode == 'bridge') | ternary('vlan', 'vxlan') }}
+        CONTIV_NETMASTER_PLUGIN_NAME={{contiv_v2plugin_image}}
+        CONTIV_NETMASTER_FORWARD_MODE={{ fwd_mode }}
+        CONTIV_NETMASTER_INTERNAL_ADDRESS={{node_addr}}:{{netmaster_port}}
+        CONTIV_NETMASTER_MODE=docker
+        {{ (cluster_store_driver == 'etcd') | ternary('CONTIV_NETMASTER_ETCD_ENDPOINTS', 'CONTIV_NETMASTER_CONSUL_ENDPOINTS') }}={{ cluster_store_url }}
 
   always:
     - name: Remove v2plugin rootfs

--- a/roles/contiv_network/templates/netmaster.j2
+++ b/roles/contiv_network/templates/netmaster.j2
@@ -1,1 +1,6 @@
-NETMASTER_ARGS="--cluster-mode {{netplugin_mode}} -cluster-store {{cluster_store}} -listen-url {{ listen_url }} -control-url {{ control_url }}"
+CONTIV_NETMASTER_NET_MODE={{ (fwd_mode == 'bridge') | ternary('vlan', 'vxlan') }}
+CONTIV_NETMASTER_PLUGIN_NAME={{contiv_v2plugin_image}}
+CONTIV_NETMASTER_FORWARD_MODE={{ fwd_mode }}
+CONTIV_NETMASTER_INTERNAL_ADDRESS={{node_addr}}:{{netmaster_port}}
+CONTIV_NETMASTER_MODE=docker
+{{ (cluster_store_driver == 'etcd') | ternary('CONTIV_NETMASTER_ETCD_ENDPOINTS', 'CONTIV_NETMASTER_CONSUL_ENDPOINTS') }}={{ cluster_store_url }}

--- a/roles/contiv_network/templates/netplugin.j2
+++ b/roles/contiv_network/templates/netplugin.j2
@@ -1,1 +1,7 @@
-NETPLUGIN_ARGS='-plugin-mode {{netplugin_mode}} -vlan-if {{netplugin_if}} -vtep-ip {{node_addr}} -ctrl-ip {{node_addr}} -cluster-store {{cluster_store}} '
+CONTIV_NETPLUGIN_CONTROL_IP={{node_addr}}
+CONTIV_NETPLUGIN_FORWARD_MODE={{ fwd_mode }}
+CONTIV_NETPLUGIN_MODE=docker
+CONTIV_NETPLUGIN_VXLAN_PORT={{vxlan_port}}
+CONTIV_NETPLUGIN_VLAN_UPLINKS={{netplugin_if}}
+CONTIV_NETPLUGIN_NET_MODE={{ (fwd_mode == 'bridge') | ternary('vlan', 'vxlan') }}
+{{ (cluster_store_driver == 'etcd') | ternary('CONTIV_NETPLUGIN_ETCD_ENDPOINTS', 'CONTIV_NETPLUGIN_CONSUL_ENDPOINTS') }}={{ cluster_store_url }}


### PR DESCRIPTION
We refactored netplugin and netmaster CLI, and these changes are
required in order to make ansible able to deploy updated services.

Signed-off-by: Wei Tie <wtie@cisco.com>