### PR TITLE
roles/{contiv,etcd}: retry pulling image & plugin

### DIFF
--- a/roles/contiv_network/tasks/v2plugin.yml
+++ b/roles/contiv_network/tasks/v2plugin.yml
@@ -25,6 +25,8 @@
 - name: install v2plugin on {{ run_as }} nodes from dockerhub
   shell: >
     /usr/bin/docker plugin install --grant-all-permissions {{contiv_v2plugin_image}} ctrl_ip={{node_addr}} control_url={{node_addr}}:{{netmaster_port}} vxlan_port={{vxlan_port}} iflist={{netplugin_if}} plugin_name={{contiv_v2plugin_image}} cluster_store={{cluster_store}} plugin_role={{run_as}} fwd_mode={{ fwd_mode }}
+  retries: 5
+  delay: 10
   when:
     - v2plugin_installed|failed
     - not v2plugin_archive_stat.stat.exists

--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -19,6 +19,8 @@
 
     - name: pull etcd container {{ etcd_version }}
       shell: docker pull quay.io/coreos/etcd:{{ etcd_version }}
+      retries: 5
+      delay: 10
       tags:
         - prebake-for-dev
 


### PR DESCRIPTION
This should help avoid issues with interrupted downloads when dealing with network connectivity problems.

This should help work around https://github.com/contiv/install/issues/340